### PR TITLE
Don't show webview until content has loaded

### DIFF
--- a/res/layout/article_view.xml
+++ b/res/layout/article_view.xml
@@ -7,6 +7,7 @@
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:visibility="gone"
     />
 
     <com.google.android.material.progressindicator.LinearProgressIndicator

--- a/src/itkach/aard2/widget/ArticleWebView.java
+++ b/src/itkach/aard2/widget/ArticleWebView.java
@@ -448,6 +448,7 @@ public class ArticleWebView extends SearchableWebView {
             }
             view.loadUrl("javascript:" + StyleJsUtils.getStyleSwitcherJs() + ";$SLOB.setStyleTitles($styleSwitcher.getTitles())");
             applyStylePref();
+            view.setVisibility(WebView.VISIBLE);
         }
 
         @Nullable


### PR DESCRIPTION
Avoid flashing in dark mode by delaying  webview display until after the content has loaded

Fixes #33 