### PR TITLE
Obtaniumify Readme Badge Link - #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     height="80">](https://f-droid.org/packages/com.akylas.aard2)
 [<img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png"
     alt="Get it with Obtainium"
-    height="80">](https://github.com/Akylas/OSS-Dict)
+    height="80">](https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/{%22id%22:%22com.akylas.aard2%22,%22url%22:%22https://github.com/Akylas/OSS-Dict/%22,%22author%22:%22Akylas%22,%22name%22:%22OSS-Dict%22})
 </div>
 
  

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
     height="80">](https://f-droid.org/packages/com.akylas.aard2)
 [<img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png"
     alt="Get it with Obtainium"
-    height="55">](https://github.com/Akylas/OSS-Dict)
+    height="80">](https://github.com/Akylas/OSS-Dict)
 </div>
 
  


### PR DESCRIPTION
This PR would resolve #92 and the bonus is it brings the Obtanium badge to the same height as the other badges.

The 9a7f4fddd67fd169aa4571df5d2c1b625ab01684 commit message:

> Updated Obtainium badge link in README.md to use the Official crowdsourced app directory re-director website. I believe the use of this website provides a better user experience than directly using the obtanium://add format as it allows non-obtanium users to have a better experience.