### PR TITLE
fix(slob): detect blocked internet permission and keep app usable

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -191,6 +191,7 @@
     <string name="setting_sort_lookup_by_rank">Sort results by best match first</string>
     <string name="permission_internet_required_title">Internet Permission Required</string>
     <string name="permission_internet_required_message">This app requires internet permission to work correctly. Even though the app does not use internet directly, it needs this permission for internal socket communication. Please enable the internet permission in your device settings.</string>
+    <string name="article_internet_permission_required">Can\'t display this article: the internet permission is needed for internal socket communication. Please enable it in your device settings.</string>
     <string name="msg_permission_denied_notifications">Permission to post notifications was denied. The app won\'t be able to notify you about new dictionaries.</string>
     <string name="rationale_notifications_needed">The app needs permission to post notifications so it can inform you when automatic folder loading finds new dictionaries.</string>
     <string name="action_allow">Allow</string>

--- a/src/itkach/aard2/MainActivity.java
+++ b/src/itkach/aard2/MainActivity.java
@@ -43,8 +43,8 @@ import itkach.aard2.dictionaries.DictionaryListFragment;
 import itkach.aard2.lookup.LookupFragment;
 import itkach.aard2.prefs.AppPrefs;
 import itkach.aard2.prefs.SettingsFragment;
-import itkach.aard2.slob.SlobServer;
 import itkach.aard2.utils.ClipboardUtils;
+import itkach.aard2.utils.ThreadUtils;
 import itkach.aard2.utils.Utils;
 
 public class MainActivity extends AppCompatActivity implements NavigationBarView.OnItemSelectedListener,
@@ -57,32 +57,52 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
     private BottomNavigationView bottomNavigationView;
     private FloatingActionButton fab;
     private int oldPosition = -1;
+    @Nullable
+    private AlertDialog internetPermissionDialog;
 
     @NonNull
     public ActionBar requireActionBar() {
         return Objects.requireNonNull(getSupportActionBar());
     }
 
+    /**
+     * Starts the embedded web server if it is not running yet and warns the user when it
+     * cannot be started because network access is disabled for the app. Runs on every
+     * foreground so that granting the permission from app settings recovers without a
+     * restart.
+     */
     private void checkInternetPermission() {
-        // Check if the app can use ServerSocket by actually testing it
-        // This is the most reliable way to detect if network access is disabled in app settings
-        boolean canUseSocket = SlobServer.canUseServerSocket(SlobHelper.LOCALHOST, 0);
-        
-        if (!canUseSocket) {
-            Log.w(TAG, "ServerSocket creation blocked - network access is disabled for this app");
-            // Show alert dialog explaining the app needs network access
-            new AlertDialog.Builder(this)
-                    .setTitle(R.string.permission_internet_required_title)
-                    .setMessage(R.string.permission_internet_required_message)
-                    .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                        Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                        intent.setData(Uri.parse("package:" + getPackageName()));
-                        startActivity(intent);
-                    })
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .setCancelable(true)
-                    .show();
-        }
+        ThreadUtils.postOnBackgroundThread(() -> {
+            boolean serverStarted = SlobHelper.getInstance().ensureServerStarted();
+            ThreadUtils.postOnMainThread(() -> {
+                if (isFinishing() || isDestroyed()) {
+                    return;
+                }
+                if (serverStarted) {
+                    if (internetPermissionDialog != null) {
+                        internetPermissionDialog.dismiss();
+                        internetPermissionDialog = null;
+                    }
+                    return;
+                }
+                Log.w(TAG, "Web server could not be started - network access is disabled for this app");
+                if (internetPermissionDialog != null) {
+                    return;
+                }
+                internetPermissionDialog = new AlertDialog.Builder(this)
+                        .setTitle(R.string.permission_internet_required_title)
+                        .setMessage(R.string.permission_internet_required_message)
+                        .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                            Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                            intent.setData(Uri.parse("package:" + getPackageName()));
+                            startActivity(intent);
+                        })
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .setCancelable(true)
+                        .setOnDismissListener(dialog -> internetPermissionDialog = null)
+                        .show();
+            });
+        });
     }
 
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -91,10 +111,7 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
         Utils.updateNightMode();
         setContentView(R.layout.activity_main);
         setSupportActionBar(findViewById(R.id.toolbar));
-        
-        // Check if INTERNET permission is granted
-        checkInternetPermission();
-        
+
         appSectionsPagerAdapter = new AppSectionsPagerAdapter(getSupportFragmentManager(), AppPrefs.disableBookmarks(), AppPrefs.disableHistory());
 
         layout = findViewById(R.id.layout);
@@ -235,6 +252,12 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        checkInternetPermission();
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         AppPrefs.getPreferences().registerOnSharedPreferenceChangeListener(this);
@@ -252,6 +275,15 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
             inputMethodManager.hideSoftInputFromWindow(focusedView.getWindowToken(), 0);
         }
         super.onPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (internetPermissionDialog != null) {
+            internetPermissionDialog.dismiss();
+            internetPermissionDialog = null;
+        }
+        super.onDestroy();
     }
 
     @Override

--- a/src/itkach/aard2/SlobHelper.java
+++ b/src/itkach/aard2/SlobHelper.java
@@ -83,8 +83,9 @@ public final class SlobHelper {
     @NonNull
     public final LookupResult lastLookupResult;
 
-    private int port = -1;
+    private volatile int port = -1;
     private volatile boolean initialized;
+    private volatile boolean serverBlocked;
 
     private SlobHelper(@NonNull Application application) {
         this.application = application;
@@ -106,19 +107,47 @@ public final class SlobHelper {
             return;
         }
         initialized = true;
-        long t0 = System.currentTimeMillis();
+        ensureServerStarted();
+        dictionaries.load();
+        bookmarks.load();
+        history.load();
+    }
+
+    /**
+     * Starts the embedded web server if it is not running yet.
+     *
+     * <p>Never throws: when the server cannot be started the app stays usable for
+     * lookup, only article rendering is unavailable. The most common cause is a
+     * denied {@code android.permission.INTERNET} (permission manager, firewall
+     * app), in which case retrying other ports is pointless and skipped.</p>
+     *
+     * <p>Called again whenever the UI comes to the foreground, so granting the
+     * permission and returning to the app recovers without a restart.</p>
+     *
+     * @return true when the server is running
+     */
+    @WorkerThread
+    public synchronized boolean ensureServerStarted() {
+        if (port > 0) {
+            return true;
+        }
+        long startTime = System.currentTimeMillis();
         int portCandidate = PREFERRED_PORT;
         try {
             SlobServer.startServer(LOCALHOST, portCandidate);
             port = portCandidate;
         } catch (IOException e) {
             Log.w(TAG, String.format("Failed to start on preferred port %d", portCandidate), e);
+            if (SlobServer.isPermissionDenied(e)) {
+                serverBlocked = true;
+                Log.e(TAG, "Cannot create a server socket: INTERNET permission is denied");
+                return false;
+            }
             Set<Integer> seen = new HashSet<>();
             seen.add(PREFERRED_PORT);
             Random rand = new Random();
             int attemptCount = 0;
-            Exception lastError = e;
-            while (true) {
+            while (port <= 0) {
                 int value = 1 + (int) Math.floor((65535 - 1025) * rand.nextDouble());
                 portCandidate = 1024 + value;
                 if (seen.contains(portCandidate)) {
@@ -129,20 +158,33 @@ public final class SlobHelper {
                 try {
                     SlobServer.startServer(LOCALHOST, portCandidate);
                     port = portCandidate;
-                    break;
-                } catch (IOException e1) {
-                    lastError = e1;
-                    Log.w(TAG, String.format("Failed to start on port %d", portCandidate), e1);
-                }
-                if (attemptCount >= 20) {
-                    throw new RuntimeException("Failed to start web server", lastError);
+                } catch (IOException retryError) {
+                    Log.w(TAG, String.format("Failed to start on port %d", portCandidate), retryError);
+                    if (SlobServer.isPermissionDenied(retryError)) {
+                        serverBlocked = true;
+                        Log.e(TAG, "Cannot create a server socket: INTERNET permission is denied");
+                        return false;
+                    }
+                    if (attemptCount >= 20) {
+                        Log.e(TAG, "Failed to start web server", retryError);
+                        return false;
+                    }
                 }
             }
         }
-        Log.d(TAG, String.format("Started web server on port %d in %d ms", port, (System.currentTimeMillis() - t0)));
-        dictionaries.load();
-        bookmarks.load();
-        history.load();
+        serverBlocked = false;
+        Log.d(TAG, String.format("Started web server on port %d in %d ms", port, (System.currentTimeMillis() - startTime)));
+        return true;
+    }
+
+    /** True when the embedded web server is running and articles can be served. */
+    public boolean isServerAvailable() {
+        return port > 0;
+    }
+
+    /** True when the server could not start because INTERNET permission is denied. */
+    public boolean isServerBlocked() {
+        return serverBlocked;
     }
 
     /**

--- a/src/itkach/aard2/article/ArticleCollectionActivity.java
+++ b/src/itkach/aard2/article/ArticleCollectionActivity.java
@@ -369,7 +369,10 @@ public class ArticleCollectionActivity extends AppCompatActivity
         ArticleFragment af = pagerAdapter.getPrimaryItem();
         if (af != null) {
             ArticleWebView webView = af.getWebView();
-
+            // No web view when the article could not be displayed (see ArticleFragment)
+            if (webView == null) {
+                return super.onKeyLongPress(keyCode, event);
+            }
             if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
                 webView.pageUp(true);
                 return true;

--- a/src/itkach/aard2/article/ArticleFragment.java
+++ b/src/itkach/aard2/article/ArticleFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -132,6 +133,17 @@ public class ArticleFragment extends Fragment {
             View layout = inflater.inflate(R.layout.empty_view, container, false);
             ImageView icon = layout.findViewById(R.id.empty_icon);
             icon.setImageResource(R.drawable.ic_block);
+            setHasOptionsMenu(false);
+            return layout;
+        }
+
+        if (!SlobHelper.getInstance().isServerAvailable()) {
+            // Articles are served over a local socket, which needs the internet permission
+            View layout = inflater.inflate(R.layout.empty_view, container, false);
+            ImageView icon = layout.findViewById(R.id.empty_icon);
+            icon.setImageResource(R.drawable.ic_block);
+            TextView emptyText = layout.findViewById(R.id.empty_text);
+            emptyText.setText(R.string.article_internet_permission_required);
             setHasOptionsMenu(false);
             return layout;
         }

--- a/src/itkach/aard2/slob/SlobServer.java
+++ b/src/itkach/aard2/slob/SlobServer.java
@@ -1,6 +1,8 @@
 package itkach.aard2.slob;
 
 import android.net.Uri;
+import android.system.ErrnoException;
+import android.system.OsConstants;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -42,6 +44,8 @@ import itkach.slob.Slob;
 // Format: host:port/auth/dictId/key?blob=<id>#fragment
 // Returns: Content with designated types and caching info.
 public class SlobServer extends Thread {
+    private static final String TAG = SlobServer.class.getSimpleName();
+
     public static final String PAGE_NOT_FOUND = "404";
     public static final String OKAY = "200";
     public static final String CREATED = "201";
@@ -435,7 +439,7 @@ public class SlobServer extends Thread {
             }
             sSlobServer = new SlobServer(ip, port);
             sSlobServer.start();
-            System.out.println("Server Started");
+            Log.d(TAG, "Server started");
         }
     }
 
@@ -444,7 +448,7 @@ public class SlobServer extends Thread {
             if (sSlobServer != null && sSlobServer.isAlive()) {
                 sSlobServer.interrupt();
             }
-            System.out.println("Server stopped");
+            Log.d(TAG, "Server stopped");
         }
     }
 
@@ -459,31 +463,24 @@ public class SlobServer extends Thread {
     }
 
     /**
-     * Test if the app has permission to use ServerSocket.
+     * Tells whether {@code error} was caused by the app lacking
+     * {@code android.permission.INTERNET}. Without that permission the kernel
+     * refuses socket creation with EACCES, surfaced as a
+     * {@link SocketException} wrapping an {@link ErrnoException}.
      */
-    public static boolean canUseServerSocket(@NonNull String ip, int port) {
-        Log.d("SlobServer", "canUseServerSocket " + ip + " " + port);
-        ServerSocket testSocket = null;
-        try {
-            testSocket = new ServerSocket(port, 0, InetAddress.getByName(ip));
-            return true;
-        } catch (SecurityException e) {
-            e.printStackTrace();
-            return false;
-        } catch (SocketException e) {
-            e.printStackTrace();
-            return !e.getMessage().contains(" ECONNREFUSED");
-        } catch (IOException e) {
-            e.printStackTrace();
-            return true;
-        } finally {
-            if (testSocket != null) {
-                try {
-                    testSocket.close();
-                } catch (IOException ignored) {
-                }
+    public static boolean isPermissionDenied(@NonNull IOException error) {
+        for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ErrnoException) {
+                int errno = ((ErrnoException) cause).errno;
+                return errno == OsConstants.EACCES || errno == OsConstants.EPERM;
+            }
+            String message = cause.getMessage();
+            if (message != null && (message.contains("EACCES") || message.contains("EPERM")
+                    || message.contains("Permission denied"))) {
+                return true;
             }
         }
+        return false;
     }
 
     @NonNull


### PR DESCRIPTION
## Summary

- Fix the INTERNET-permission check: `canUseServerSocket()` matched the error message against `ECONNREFUSED`, so a denied permission (`socket failed: EACCES/EPERM`) was read as "socket fine" and the warning dialog never appeared. Replaced by `SlobServer.isPermissionDenied()`, which inspects the `ErrnoException` in the cause chain.
- Drive the check from the real bind attempt (`SlobHelper.ensureServerStarted()`) instead of a separate probe socket. It never throws and skips the 20 random-port retries when the permission is the problem, so `init()` always goes on to load dictionaries, bookmarks and history — a blocked socket no longer wipes the dictionary list (the "my dictionaries disappeared" reports in #34).
- Re-check on every `MainActivity.onStart` (off the main thread) and dismiss the dialog once the server starts, so granting the permission and coming back recovers without a restart.
- Show an explanatory message in the article view instead of a blank page when the server is unavailable.

## Testing

`assembleDebug` compiles; `lint` adds only the expected `MissingTranslation` for the new string (Weblate-managed); `testDebugUnitTest` stays at the known-red `Slob$Strength` baseline, no new failures.

Manual, on an emulator with a StarDict test dictionary:

- Permission granted: server starts on 8489, no dialog, article renders.
- Permission denied (built with the `<uses-permission>` line stripped): logcat shows `socket failed: EPERM` then `Cannot create a server socket: INTERNET permission is denied`, dialog shows, no `RuntimeException`, no retry spam. The dictionary still loads and search still finds words; opening an article shows the new message instead of a blank page.

Not covered: granting the permission while the app keeps running. Install-time permissions can't be toggled at runtime on a stock emulator — that path needs a ROM with a real network toggle (GrapheneOS) or a firewall app.

Fixes #89