### PR TITLE
fix(proguard): keep Parcelable CREATOR so minified builds can restore state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ android {
 //        debug {
 //            minifyEnabled true
 //            shrinkResources true
-//            proguardFiles("proguard-rules.pro")
+//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), "proguard-rules.pro"
 //            zipAlignEnabled true
 //        }
         release {
@@ -114,7 +114,9 @@ android {
             if (System.getenv("KEYSTORE") != null) {
                 signingConfig signingConfigs.release
             }
-            proguardFiles("proguard-rules.pro")
+            // the default file carries the stock rules (Parcelable CREATOR, native methods,
+            // @Keep, View animator accessors) - listing only our file would drop them
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), "proguard-rules.pro"
         }
     }
     buildFeatures {

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -54,3 +54,8 @@
     @android.webkit.JavascriptInterface <methods>;
 }
 
+# Saved instance state written by one release is unparcelled by the next: the class
+# names stored in the bundle must still resolve after an update, so they must not
+# move between releases. The CREATOR members themselves come from the default file.
+-keepnames class * implements android.os.Parcelable
+

--- a/src/itkach/aard2/MainActivity.java
+++ b/src/itkach/aard2/MainActivity.java
@@ -107,6 +107,7 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
 
     public void onCreate(@Nullable Bundle savedInstanceState) {
         EdgeToEdge.enable(this);
+        savedInstanceState = Utils.sanitizeSavedState(savedInstanceState, getClassLoader());
         super.onCreate(savedInstanceState);
         Utils.updateNightMode();
         setContentView(R.layout.activity_main);

--- a/src/itkach/aard2/article/ArticleCollectionActivity.java
+++ b/src/itkach/aard2/article/ArticleCollectionActivity.java
@@ -75,6 +75,7 @@ public class ArticleCollectionActivity extends AppCompatActivity
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         EdgeToEdge.enable(this);
+        savedInstanceState = Utils.sanitizeSavedState(savedInstanceState, getClassLoader());
         super.onCreate(savedInstanceState);
         Utils.updateNightMode();
         setContentView(R.layout.activity_article_collection_loading);

--- a/src/itkach/aard2/utils/Utils.java
+++ b/src/itkach/aard2/utils/Utils.java
@@ -3,6 +3,7 @@ package itkach.aard2.utils;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.net.Uri;
+import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -15,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -94,6 +96,42 @@ public class Utils {
     public static boolean isNightMode(@NonNull Context context) {
         int nightModeFlags = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
         return nightModeFlags == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    /**
+     * Reads the whole saved instance state eagerly so that a bundle which cannot be unparcelled
+     * is detected here instead of crashing inside {@code super.onCreate}. State saved by an
+     * earlier release stores class names as they were obfuscated back then; after an update those
+     * names may resolve to a different class or to none at all, which makes the framework throw
+     * {@link android.os.BadParcelableException} while restoring fragments. Dropping the state
+     * costs a fresh start, keeping it costs a start-up crash loop.
+     *
+     * @return the bundle itself when it can be read, null when it cannot
+     */
+    @Nullable
+    public static Bundle sanitizeSavedState(@Nullable Bundle savedState, @NonNull ClassLoader classLoader) {
+        if (savedState == null) {
+            return null;
+        }
+        try {
+            unparcelDeep(savedState, classLoader);
+        } catch (RuntimeException e) {
+            Log.w(TAG, "Unreadable saved instance state, starting without it:", e);
+            return null;
+        }
+        return savedState;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void unparcelDeep(@NonNull Bundle bundle, @NonNull ClassLoader classLoader) {
+        bundle.setClassLoader(classLoader);
+        // iterate over a copy: reading a value replaces it in the backing map
+        for (String key : new ArrayList<>(bundle.keySet())) {
+            Object value = bundle.get(key);
+            if (value instanceof Bundle) {
+                unparcelDeep((Bundle) value, classLoader);
+            }
+        }
     }
 
     @NonNull


### PR DESCRIPTION
## Summary

- Release builds passed `proguardFiles("proguard-rules.pro")`, which **replaces** the default AGP config instead of extending it. R8 therefore stripped the `CREATOR` fields of the AndroidX saved-state classes (read reflectively only), and start-up crashed with `BadParcelableException: ... CREATOR ... androidx.fragment.app.g1` whenever the system restored a marshalled instance state (process death, relaunch from recents). Now `getDefaultProguardFile('proguard-android-optimize.txt')` is applied again — which also restores the other stock rules (native-method names, `@Keep`, View animator accessors).
- Added `-keepnames class * implements android.os.Parcelable`: saved state written by one release is unparcelled by the next, so those class names must not move between releases.
- Added `Utils.sanitizeSavedState(...)`, called before `super.onCreate` in `MainActivity` and `ArticleCollectionActivity`: it reads the bundle eagerly and drops it when it cannot be unparcelled. This breaks the crash loop for users upgrading from an affected build, whose stored state still references the old obfuscated names.

## Testing

Root cause and fix proven by building the release twice — same tree, only the build config reverted:

| | pre-fix | post-fix |
|---|---|---|
| `CREATOR` fields kept by R8 (`seeds.txt`) | 8 | 46 |
| `FragmentManagerState.CREATOR` | listed in `usage.txt` (removed) | kept |
| `FragmentManagerState` class name | obfuscated | maps to itself |

- `./gradlew assembleDebug` / `assembleRelease` — green
- `./gradlew lint` — no new issue in `build/reports/lint-results-debug.txt` (existing errors are the pre-existing `GestureBackNavigation` ones)
- `./gradlew testDebugUnitTest` — unchanged from the `master` baseline (all failures are the known `Slob$Strength` static-init NPE)

Still needs a manual check on device with a signed release build:
1. Developer options → *Don't keep activities*, open the app, switch away and back, relaunch from recents — no crash.
2. Install this build over 2.0.6 while it has saved state — must start clean instead of crash-looping.

Fixes #93