### PR TITLE
fix(fastlane): commit release notes before build so the tag matches the built revision

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -122,6 +122,18 @@ lane :build_flavor do |params|
     git_commit(path: ["./*.gradle"], message: "chore: new build", allow_nothing_to_commit: true)
   end
 
+  tag = "#{tag_prefix}#{version}/#{versionCode}";
+  changelog = get_changelog(platform:platform, flavor:flavor, commit_url:commit_url)
+  puts "changelog:"  + changelog
+
+  # release notes MUST be committed before the build: AGP embeds the build time HEAD sha in
+  # META-INF/version-control-info.textproto and the tag is later put on HEAD. Any commit created
+  # between the build and the tag makes tag != APK revision, which breaks F-Droid reproducible
+  # builds (issue #86). Nothing may commit after build() and before add_git_tag.
+  if (options[:publish] != false && platform == 'android')
+    write_changelog(version:versionCode, changelog: flavor != 'github' ? changelog : get_changelog(platform:platform, flavor:'store', commit_url:commit_url));
+  end
+
   build_output = build(flavor: flavor, options: options)
   puts "build_output #{JSON.pretty_generate(build_output)}"
 
@@ -131,13 +143,14 @@ lane :build_flavor do |params|
     push_to_git_remote(tags:false)
   end
 
-  tag = "#{tag_prefix}#{version}/#{versionCode}";
-  changelog = get_changelog(platform:platform, flavor:flavor, commit_url:commit_url)
-  puts "changelog:"  + changelog
-
   if (options[:publish] != false)
-    if (platform == 'android')
-      write_changelog(version:versionCode, changelog: flavor != 'github' ? changelog : get_changelog(platform:platform, flavor:'store', commit_url:commit_url));
+    # tag the exact commit that was built and push it before creating the release, so GitHub
+    # attaches the release to it instead of creating the tag itself at the (stale) remote HEAD
+    if (options[:create_tag] != false)
+      if !git_tag_exists(tag: tag)
+        add_git_tag(tag: tag, force: true)
+        push_git_tags(force: true)
+      end
     end
     case flavor
     when 'appcenter'
@@ -169,12 +182,6 @@ lane :build_flavor do |params|
     #   end
       when 'alpha','beta','production'
         upload_store(changelog:changelog, version: version, versionCode: versionCode, flavor:flavor, options:options, build_output:build_output)
-    end
-    if (options[:create_tag] != false)
-      if !git_tag_exists(tag: tag)
-        add_git_tag(tag: tag, force: true)
-        push_git_tags(force: true)
-      end
     end
     # we need to pull to be able to push again
     git_pull


### PR DESCRIPTION
## Summary

- Move the `N release notes` commit above `build(...)` in the `build_flavor` lane. AGP embeds the build-time HEAD sha in `META-INF/version-control-info.textproto`, and the release tag is put on HEAD after the build — the changelog commit landing in between made the tag point one commit past the built revision (`v2.0.5/78` → `8d7b2cb` while the APK said `5c86f3f`, `v2.0.6/79` → `39eb539` vs `71d4432`). F-Droid rebuilds from the tag, gets a different revision, and refuses the autoupdate.
- Create and push the tag before `set_github_release`, so GitHub attaches the release to an existing correct tag instead of creating it at the stale remote HEAD and having it force-moved a moment later.

Invariant to keep in mind when touching this lane: nothing may commit between `build(...)` and `add_git_tag`. Noted in a comment there.

The tag is still created only after a successful build — a failed build leaves no tag, and in CI leaves nothing at all on the remote (all pushes happen after `build(...)`, and the runner is discarded).

Behavior change worth a look: the tag is now pushed before the asset upload, so a failed `set_github_release` leaves a pushed tag. It still points at a genuinely built commit, and a rerun skips tag creation via `git_tag_exists` and creates the release on it.

## Testing

- `ruby -c fastlane/Fastfile` → Syntax OK
- `./gradlew assembleRelease` → BUILD SUCCESSFUL; the APK's embedded revision matches HEAD exactly (`f55c2c9…` both), confirming the mechanism the fix relies on
- No Java or resource change, so no compile/lint gate applies
- Full verification only lands on the next real release run: `git rev-list -1 <tag>` must equal the `revision:` in the published APK's `META-INF/version-control-info.textproto`

Fixes #86