### PR TITLE
feat(settings): export and import bookmarks and history

### DIFF
--- a/res/layout/settings_backup_item.xml
+++ b/res/layout/settings_backup_item.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/card_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp">
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurface"
+            android:text="@string/setting_backup" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text="@string/setting_backup_subtitle" />
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/export_backup_button"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/action_export" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/import_backup_button"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_weight="1"
+                android:text="@string/action_import" />
+        </androidx.appcompat.widget.LinearLayoutCompat>
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+</com.google.android.material.card.MaterialCardView>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -203,6 +203,17 @@
     <string name="settings_section_article_view">Article View</string>
     <string name="settings_section_lookup">Lookup</string>
     <string name="settings_section_features">Features</string>
+    <string name="settings_section_backup">Backup</string>
+
+    <!-- Backup section -->
+    <string name="setting_backup">Bookmarks &amp; History</string>
+    <string name="setting_backup_subtitle">Save to a file to move them to another device. Importing keeps what you already have.</string>
+    <string name="action_export">Export</string>
+    <string name="action_import">Import</string>
+    <string name="msg_backup_exported">Exported %1$d bookmarks, %2$d history entries</string>
+    <string name="msg_backup_imported">Imported %1$d bookmarks, %2$d history entries</string>
+    <string name="msg_backup_export_failed">Failed to write backup file</string>
+    <string name="msg_backup_import_failed">Not a valid backup file</string>
 
     <!-- About section -->
     <string name="setting_about_source">Source Code</string>

--- a/src/itkach/aard2/BlobDescriptorList.java
+++ b/src/itkach/aard2/BlobDescriptorList.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.MainThread;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import android.icu.text.Collator;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 
 import itkach.aard2.descriptor.BlobDescriptor;
+import itkach.aard2.descriptor.BlobDescriptorBackup;
 import itkach.aard2.descriptor.DescriptorStore;
 import itkach.aard2.dictionary.Dictionary;
 import itkach.aard2.dictionary.DictionaryEntry;
@@ -241,13 +243,45 @@ public class BlobDescriptorList extends AbstractList<BlobDescriptor> {
         }
         this.list.add(bd);
         store.save(bd);
-        if (this.list.size() > this.maxSize) {
-            Utils.sort(this.list, lastAccessComparator);
+        trimToMaxSize();
+        notifyDataSetChanged();
+        return bd;
+    }
+
+    /**
+     * Drops least recently accessed entries until the list fits {@link #maxSize}.
+     *
+     * <p>Loops because an import adds many entries at once, unlike {@link #add(Uri)}.</p>
+     */
+    protected void trimToMaxSize() {
+        if (this.list.size() <= this.maxSize) {
+            return;
+        }
+        Utils.sort(this.list, lastAccessComparator);
+        while (this.list.size() > this.maxSize) {
             BlobDescriptor lru = this.list.remove(this.list.size() - 1);
             store.delete(lru.id);
         }
+    }
+
+    /**
+     * Merges descriptors read from a backup file into this list.
+     *
+     * <p>Nothing is replaced or removed: entries already present are skipped
+     * (see {@link BlobDescriptorBackup#selectNew}).</p>
+     *
+     * @return the number of entries actually added
+     */
+    @MainThread
+    public int importDescriptors(@NonNull List<BlobDescriptor> imported) {
+        List<BlobDescriptor> added = BlobDescriptorBackup.selectNew(this.list, imported);
+        for (BlobDescriptor bd : added) {
+            this.list.add(bd);
+            store.save(bd);
+        }
+        trimToMaxSize();
         notifyDataSetChanged();
-        return bd;
+        return added.size();
     }
 
     public BlobDescriptor remove(Uri contentUrl) {

--- a/src/itkach/aard2/HistoryBlobDescriptorList.java
+++ b/src/itkach/aard2/HistoryBlobDescriptorList.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 
 import itkach.aard2.descriptor.BlobDescriptor;
 import itkach.aard2.descriptor.DescriptorStore;
-import itkach.aard2.utils.Utils;
 
 public class HistoryBlobDescriptorList extends BlobDescriptorList {
     HistoryBlobDescriptorList(DescriptorStore<BlobDescriptor> store) {
@@ -32,11 +31,7 @@ public class HistoryBlobDescriptorList extends BlobDescriptorList {
         }
         list.add(bd);
         store.save(bd);
-        if (list.size() > maxSize) {
-            Utils.sort(list, lastAccessComparator);
-            BlobDescriptor lru = list.remove(list.size() - 1);
-            store.delete(lru.id);
-        }
+        trimToMaxSize();
         notifyDataSetChanged();
         return bd;
     }

--- a/src/itkach/aard2/SlobHelper.java
+++ b/src/itkach/aard2/SlobHelper.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,6 +27,7 @@ import java.util.Random;
 import java.util.Set;
 
 import itkach.aard2.descriptor.BlobDescriptor;
+import itkach.aard2.descriptor.BlobDescriptorBackup;
 import itkach.aard2.descriptor.DescriptorStore;
 import itkach.aard2.descriptor.SlobDescriptor;
 import itkach.aard2.dictionary.Dictionary;
@@ -95,7 +99,9 @@ public final class SlobHelper {
         bookmarkStore = new DescriptorStore<>(mapper, application.getDir("bookmarks", Context.MODE_PRIVATE));
         historyStore = new DescriptorStore<>(mapper, application.getDir("history", Context.MODE_PRIVATE));
         dictionaries = new SlobDescriptorList(dictStore);
-        bookmarks = new BlobDescriptorList(bookmarkStore);
+        // Bookmarks are kept uncapped: they are user curated, and restoring a backup from
+        // another device must not silently drop entries. History stays capped.
+        bookmarks = new BlobDescriptorList(bookmarkStore, Integer.MAX_VALUE);
         history = new HistoryBlobDescriptorList(historyStore);
         lastLookupResult = new LookupResult();
         random = new Random();
@@ -185,6 +191,35 @@ public final class SlobHelper {
     /** True when the server could not start because INTERNET permission is denied. */
     public boolean isServerBlocked() {
         return serverBlocked;
+    }
+
+    /**
+     * Copies the current bookmarks and history so a backup can be written off the main thread
+     * without racing with list updates.
+     */
+    @MainThread
+    @NonNull
+    public BlobDescriptorBackup.Content snapshotForBackup() {
+        return new BlobDescriptorBackup.Content(
+                new ArrayList<>(bookmarks.getList()), new ArrayList<>(history.getList()));
+    }
+
+    /** Writes a snapshot taken by {@link #snapshotForBackup()} as a backup document. */
+    @WorkerThread
+    public void writeBackup(@NonNull OutputStream out, @NonNull BlobDescriptorBackup.Content content)
+            throws IOException {
+        BlobDescriptorBackup.write(out, mapper, content.bookmarks, content.history,
+                System.currentTimeMillis());
+    }
+
+    /**
+     * Parses a backup document. Applying it to the lists must happen on the main thread, see
+     * {@link BlobDescriptorList#importDescriptors(List)}.
+     */
+    @WorkerThread
+    @NonNull
+    public BlobDescriptorBackup.Content readBackup(@NonNull InputStream in) throws IOException {
+        return BlobDescriptorBackup.read(in, mapper);
     }
 
     /**

--- a/src/itkach/aard2/descriptor/BlobDescriptorBackup.java
+++ b/src/itkach/aard2/descriptor/BlobDescriptorBackup.java
@@ -1,0 +1,226 @@
+package itkach.aard2.descriptor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Reads and writes the bookmarks/history backup file used to migrate to another device.
+ *
+ * <p>Deliberately free of any Android dependency: the app's unit tests run on a plain JVM
+ * with {@code returnDefaultValues true}, so framework calls (including
+ * {@code android.text.TextUtils}) would silently return defaults instead of working.</p>
+ *
+ * <p>Entries are written with the same field names {@link DescriptorStore} persists, so a
+ * descriptor round-trips through a backup without any translation layer. The Jackson tree
+ * API is used rather than data binding, mirroring {@code DescriptorStore.save}.</p>
+ */
+public final class BlobDescriptorBackup {
+
+    /** Marker identifying our backup files, written as the {@code format} property. */
+    public static final String FORMAT = "oss-dict-backup";
+
+    /** Layout version of the file this class writes. Older versions stay readable. */
+    public static final int VERSION = 1;
+
+    private static final String PROP_FORMAT = "format";
+    private static final String PROP_VERSION = "version";
+    private static final String PROP_EXPORTED_AT = "exportedAt";
+    private static final String PROP_BOOKMARKS = "bookmarks";
+    private static final String PROP_HISTORY = "history";
+
+    /** Parsed backup file content. */
+    public static final class Content {
+        @NonNull
+        public final List<BlobDescriptor> bookmarks;
+        @NonNull
+        public final List<BlobDescriptor> history;
+
+        Content(@NonNull List<BlobDescriptor> bookmarks, @NonNull List<BlobDescriptor> history) {
+            this.bookmarks = bookmarks;
+            this.history = history;
+        }
+    }
+
+    private BlobDescriptorBackup() {
+    }
+
+    /**
+     * Writes both lists as a single backup document.
+     *
+     * @param exportedAt timestamp stored in the file, passed in so callers (and tests) control it
+     */
+    public static void write(@NonNull OutputStream out, @NonNull ObjectMapper mapper,
+                             @NonNull List<BlobDescriptor> bookmarks,
+                             @NonNull List<BlobDescriptor> history,
+                             long exportedAt) throws IOException {
+        ObjectNode root = mapper.createObjectNode();
+        root.put(PROP_FORMAT, FORMAT);
+        root.put(PROP_VERSION, VERSION);
+        root.put(PROP_EXPORTED_AT, exportedAt);
+        root.set(PROP_BOOKMARKS, toArray(mapper, bookmarks));
+        root.set(PROP_HISTORY, toArray(mapper, history));
+        mapper.writeValue(out, root);
+    }
+
+    /**
+     * Parses a backup document.
+     *
+     * <p>Entries without a dictionary id or key are dropped, the same guard
+     * {@code BlobDescriptorList.load()} applies to stored descriptors.</p>
+     *
+     * @throws IOException when the stream is not a readable backup of a known version
+     */
+    @NonNull
+    public static Content read(@NonNull InputStream in, @NonNull ObjectMapper mapper) throws IOException {
+        JsonNode root = mapper.readTree(in);
+        if (root == null || !root.isObject()) {
+            throw new IOException("Not a backup file: expected a JSON object");
+        }
+        String format = getText(root, PROP_FORMAT);
+        if (!FORMAT.equals(format)) {
+            throw new IOException("Not a backup file: format is " + format);
+        }
+        JsonNode versionNode = root.get(PROP_VERSION);
+        int version = versionNode == null ? 0 : versionNode.asInt(0);
+        if (version < 1 || version > VERSION) {
+            throw new IOException("Unsupported backup version: " + version);
+        }
+        return new Content(toDescriptors(root.get(PROP_BOOKMARKS)), toDescriptors(root.get(PROP_HISTORY)));
+    }
+
+    /**
+     * Picks the entries of {@code imported} that are not already in {@code existing}, leaving
+     * {@code existing} untouched (merge semantics: nothing is replaced or removed).
+     *
+     * <p>Accepted entries get a fresh id when theirs is missing or already taken - ids are
+     * file names in {@link DescriptorStore}, so a collision would overwrite an existing entry.
+     * That id is written on the imported descriptor itself, which callers are expected to have
+     * just parsed from a backup file. Duplicates within {@code imported} are dropped too.</p>
+     */
+    @NonNull
+    public static List<BlobDescriptor> selectNew(@NonNull List<BlobDescriptor> existing,
+                                                 @NonNull List<BlobDescriptor> imported) {
+        List<BlobDescriptor> accepted = new ArrayList<>();
+        Set<String> usedIds = new HashSet<>();
+        for (BlobDescriptor descriptor : existing) {
+            if (descriptor != null && descriptor.id != null) {
+                usedIds.add(descriptor.id);
+            }
+        }
+        for (BlobDescriptor candidate : imported) {
+            if (candidate == null) {
+                continue;
+            }
+            if (contains(existing, candidate) || contains(accepted, candidate)) {
+                continue;
+            }
+            if (candidate.id == null || candidate.id.trim().isEmpty() || usedIds.contains(candidate.id)) {
+                candidate.id = UUID.randomUUID().toString();
+            }
+            usedIds.add(candidate.id);
+            accepted.add(candidate);
+        }
+        return accepted;
+    }
+
+    /**
+     * Same rule as {@code BlobDescriptorList.contains}: an exact descriptor match, or the same
+     * key in the same dictionary (the descriptor was recreated after the dictionary changed).
+     */
+    private static boolean contains(@NonNull List<BlobDescriptor> list, @NonNull BlobDescriptor candidate) {
+        for (BlobDescriptor descriptor : list) {
+            if (descriptor == null) {
+                continue;
+            }
+            if (descriptor.equals(candidate)) {
+                return true;
+            }
+            if (Objects.equals(descriptor.key, candidate.key)
+                    && Objects.equals(descriptor.slobUri, candidate.slobUri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @NonNull
+    private static ArrayNode toArray(@NonNull ObjectMapper mapper, @NonNull List<BlobDescriptor> descriptors) {
+        ArrayNode array = mapper.createArrayNode();
+        for (BlobDescriptor descriptor : descriptors) {
+            if (descriptor == null) {
+                continue;
+            }
+            ObjectNode node = mapper.createObjectNode();
+            node.put("id", descriptor.id);
+            node.put("createdAt", descriptor.createdAt);
+            node.put("lastAccess", descriptor.lastAccess);
+            node.put("slobId", descriptor.slobId);
+            node.put("slobUri", descriptor.slobUri);
+            node.put("blobId", descriptor.blobId);
+            node.put("key", descriptor.key);
+            node.put("fragment", descriptor.fragment);
+            array.add(node);
+        }
+        return array;
+    }
+
+    @NonNull
+    private static List<BlobDescriptor> toDescriptors(@Nullable JsonNode array) {
+        List<BlobDescriptor> result = new ArrayList<>();
+        if (array == null || !array.isArray()) {
+            return result;
+        }
+        for (JsonNode node : array) {
+            if (node == null || !node.isObject()) {
+                continue;
+            }
+            BlobDescriptor descriptor = new BlobDescriptor();
+            descriptor.id = getText(node, "id");
+            descriptor.createdAt = getLong(node, "createdAt");
+            descriptor.lastAccess = getLong(node, "lastAccess");
+            descriptor.slobId = getText(node, "slobId");
+            descriptor.slobUri = getText(node, "slobUri");
+            descriptor.blobId = getText(node, "blobId");
+            descriptor.key = getText(node, "key");
+            descriptor.fragment = getText(node, "fragment");
+            if (isEmpty(descriptor.slobId) || isEmpty(descriptor.key)) {
+                continue;
+            }
+            result.add(descriptor);
+        }
+        return result;
+    }
+
+    private static boolean isEmpty(@Nullable String value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Nullable
+    private static String getText(@NonNull JsonNode node, @NonNull String property) {
+        JsonNode value = node.get(property);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.asText(null);
+    }
+
+    private static long getLong(@NonNull JsonNode node, @NonNull String property) {
+        JsonNode value = node.get(property);
+        return value == null || value.isNull() ? 0L : value.asLong(0L);
+    }
+}

--- a/src/itkach/aard2/descriptor/BlobDescriptorBackup.java
+++ b/src/itkach/aard2/descriptor/BlobDescriptorBackup.java
@@ -50,7 +50,7 @@ public final class BlobDescriptorBackup {
         @NonNull
         public final List<BlobDescriptor> history;
 
-        Content(@NonNull List<BlobDescriptor> bookmarks, @NonNull List<BlobDescriptor> history) {
+        public Content(@NonNull List<BlobDescriptor> bookmarks, @NonNull List<BlobDescriptor> history) {
             this.bookmarks = bookmarks;
             this.history = history;
         }

--- a/src/itkach/aard2/prefs/SettingsFragment.java
+++ b/src/itkach/aard2/prefs/SettingsFragment.java
@@ -1,5 +1,7 @@
 package itkach.aard2.prefs;
 
+import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -22,12 +24,18 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 
 import com.google.android.material.snackbar.Snackbar;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import itkach.aard2.MainActivity;
 import itkach.aard2.R;
+import itkach.aard2.SlobHelper;
+import itkach.aard2.descriptor.BlobDescriptorBackup;
 import itkach.aard2.dictionaries.DictionaryFolderManager;
+import itkach.aard2.utils.ThreadUtils;
 import itkach.aard2.utils.Utils;
 import itkach.aard2.widget.RecyclerView;
 
@@ -75,6 +83,27 @@ public class SettingsFragment extends Fragment {
                         Toast.makeText(requireActivity(), R.string.msg_failed_to_read_file, Toast.LENGTH_LONG).show();
                     }
                 }
+            });
+
+    private static final String BACKUP_FILE_NAME = "oss-dict-backup.json";
+    private static final int BACKUP_MAX_CHARS = 8 * 1024 * 1024;
+
+    public final ActivityResultLauncher<String> backupExportChooser = registerForActivityResult(
+            new ActivityResultContracts.CreateDocument("application/json"),
+            uri -> {
+                if (uri == null) {
+                    return;
+                }
+                writeBackupTo(uri);
+            });
+
+    public final ActivityResultLauncher<String[]> backupImportChooser = registerForActivityResult(
+            new ActivityResultContracts.OpenDocument(),
+            uri -> {
+                if (uri == null) {
+                    return;
+                }
+                readBackupFrom(uri);
             });
 
     @Nullable private Uri pendingAutoLoadUri;
@@ -187,6 +216,82 @@ public class SettingsFragment extends Fragment {
         }
     }
     
+    /** Asks the user where to write the bookmarks/history backup. */
+    public void exportBackup() {
+        try {
+            backupExportChooser.launch(BACKUP_FILE_NAME);
+        } catch (ActivityNotFoundException e) {
+            Log.d(TAG, "No activity to create a document", e);
+            Toast.makeText(requireActivity(), R.string.msg_no_activity_to_get_content, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    /** Asks the user for a backup file to merge into bookmarks and history. */
+    public void importBackup() {
+        try {
+            // Providers label .json inconsistently, so accept anything rather than hide the file.
+            backupImportChooser.launch(new String[]{"application/json", "text/plain", "*/*"});
+        } catch (ActivityNotFoundException e) {
+            Log.d(TAG, "No activity to open a document", e);
+            Toast.makeText(requireActivity(), R.string.msg_no_activity_to_get_content, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private void writeBackupTo(@NonNull Uri uri) {
+        Context appContext = requireContext().getApplicationContext();
+        SlobHelper slobHelper = SlobHelper.getInstance();
+        // Snapshot here, on the main thread, so the file is written off a stable copy.
+        BlobDescriptorBackup.Content snapshot = slobHelper.snapshotForBackup();
+        int bookmarkCount = snapshot.bookmarks.size();
+        int historyCount = snapshot.history.size();
+        ThreadUtils.postOnBackgroundThread(() -> {
+            try (OutputStream outputStream = appContext.getContentResolver().openOutputStream(uri, "wt")) {
+                if (outputStream == null) {
+                    throw new IOException("Could not open " + uri + " for writing");
+                }
+                slobHelper.writeBackup(outputStream, snapshot);
+            } catch (IOException | SecurityException e) {
+                Log.w(TAG, "Failed to write backup", e);
+                showToast(appContext, appContext.getString(R.string.msg_backup_export_failed));
+                return;
+            }
+            showToast(appContext, appContext.getString(R.string.msg_backup_exported,
+                    bookmarkCount, historyCount));
+        });
+    }
+
+    private void readBackupFrom(@NonNull Uri uri) {
+        Context appContext = requireContext().getApplicationContext();
+        SlobHelper slobHelper = SlobHelper.getInstance();
+        ThreadUtils.postOnBackgroundThread(() -> {
+            BlobDescriptorBackup.Content content;
+            try (InputStream inputStream = appContext.getContentResolver().openInputStream(uri)) {
+                if (inputStream == null) {
+                    throw new IOException("Could not open " + uri + " for reading");
+                }
+                // Bounded read: the picked file is arbitrary, don't let it exhaust memory.
+                String json = Utils.readStream(inputStream, BACKUP_MAX_CHARS);
+                content = slobHelper.readBackup(
+                        new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+            } catch (IOException | SecurityException e) {
+                Log.w(TAG, "Failed to read backup", e);
+                showToast(appContext, appContext.getString(R.string.msg_backup_import_failed));
+                return;
+            }
+            ThreadUtils.postOnMainThread(() -> {
+                int bookmarksAdded = slobHelper.bookmarks.importDescriptors(content.bookmarks);
+                int historyAdded = slobHelper.history.importDescriptors(content.history);
+                Toast.makeText(appContext, appContext.getString(R.string.msg_backup_imported,
+                        bookmarksAdded, historyAdded), Toast.LENGTH_LONG).show();
+            });
+        });
+    }
+
+    private static void showToast(@NonNull Context appContext, @NonNull String message) {
+        ThreadUtils.postOnMainThread(() ->
+                Toast.makeText(appContext, message, Toast.LENGTH_LONG).show());
+    }
+
     public void clearAutoLoadFolder() {
         // Use DictionaryFolderManager singleton which handles everything
         DictionaryFolderManager.getInstance(requireContext()).clearAutoLoadFolder(null);

--- a/src/itkach/aard2/prefs/SettingsListAdapter.java
+++ b/src/itkach/aard2/prefs/SettingsListAdapter.java
@@ -55,6 +55,7 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
     private static final int VIEW_TYPE_USER_STYLES    = 5;
     private static final int VIEW_TYPE_CLEAR_CACHE    = 6;
     private static final int VIEW_TYPE_ABOUT          = 7;
+    private static final int VIEW_TYPE_BACKUP         = 8;
 
     // Stable item IDs – never change these values
     private static final long ID_SECTION_APPEARANCE   = 101;
@@ -63,6 +64,7 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
     private static final long ID_SECTION_ARTICLE_VIEW = 104;
     private static final long ID_SECTION_LOOKUP       = 105;
     private static final long ID_SECTION_FEATURES     = 106;
+    private static final long ID_SECTION_BACKUP       = 107;
 
     private static final long ID_UI_THEME             = 201;
     private static final long ID_FORCE_DARK           = 202;
@@ -90,6 +92,8 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
     private static final long ID_DISABLE_HISTORY      = 704;
 
     private static final long ID_ABOUT                = 801;
+
+    private static final long ID_BACKUP               = 901;
 
     // -------------------------------------------------------------------------
     // Functional interface for boolean preference read/write
@@ -173,6 +177,11 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
     static class ClearCacheItem extends Item {
         @Override public int getViewType()  { return VIEW_TYPE_CLEAR_CACHE; }
         @Override public long getStableId() { return ID_CLEAR_CACHE; }
+    }
+
+    static class BackupItem extends Item {
+        @Override public int getViewType()  { return VIEW_TYPE_BACKUP; }
+        @Override public long getStableId() { return ID_BACKUP; }
     }
 
     static class AboutItem extends Item {
@@ -321,6 +330,10 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
                     @Override public void set(boolean v) { AppPrefs.setDisableHistory(v); }
                 }));
 
+        // --- Backup ---
+        list.add(new SectionHeaderItem(ID_SECTION_BACKUP, R.string.settings_section_backup));
+        list.add(new BackupItem());
+
         // --- About (always last) ---
         list.add(new AboutItem());
 
@@ -358,6 +371,7 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
             case VIEW_TYPE_AUTO_LOAD_FOLDER: layoutRes = R.layout.settings_auto_load_folder_item; break;
             case VIEW_TYPE_USER_STYLES:      layoutRes = R.layout.settings_user_styles_item;      break;
             case VIEW_TYPE_CLEAR_CACHE:      layoutRes = R.layout.settings_clear_cache_item;      break;
+            case VIEW_TYPE_BACKUP:           layoutRes = R.layout.settings_backup_item;           break;
             case VIEW_TYPE_ABOUT:            layoutRes = R.layout.settings_about_item;            break;
             default: throw new RuntimeException("Unknown view type: " + viewType);
         }
@@ -376,6 +390,7 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
             case VIEW_TYPE_AUTO_LOAD_FOLDER: bindAutoLoadFolder(holder);                           break;
             case VIEW_TYPE_USER_STYLES:      bindUserStyles(holder);                               break;
             case VIEW_TYPE_CLEAR_CACHE:      bindClearCache(holder);                               break;
+            case VIEW_TYPE_BACKUP:           bindBackup(holder);                                   break;
             case VIEW_TYPE_ABOUT:            bindAbout(holder);                                    break;
         }
     }
@@ -578,6 +593,23 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
                         })
                         .setNegativeButton(R.string.action_no, null)
                         .show());
+    }
+
+    private void bindBackup(@NonNull ViewHolder holder) {
+        View view = holder.itemView;
+        MaterialButton exportBtn = view.findViewById(R.id.export_backup_button);
+        MaterialButton importBtn = view.findViewById(R.id.import_backup_button);
+
+        exportBtn.setOnClickListener(v -> {
+            if (fragment instanceof SettingsFragment) {
+                ((SettingsFragment) fragment).exportBackup();
+            }
+        });
+        importBtn.setOnClickListener(v -> {
+            if (fragment instanceof SettingsFragment) {
+                ((SettingsFragment) fragment).importBackup();
+            }
+        });
     }
 
     private void bindAbout(@NonNull ViewHolder holder) {

--- a/src/test/java/itkach/aard2/descriptor/BlobDescriptorBackupTest.java
+++ b/src/test/java/itkach/aard2/descriptor/BlobDescriptorBackupTest.java
@@ -1,0 +1,247 @@
+package itkach.aard2.descriptor;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for {@link BlobDescriptorBackup}, the bookmarks/history backup format.
+ *
+ * <p>Pure JVM: the class under test has no Android dependency, so these run despite the
+ * {@code returnDefaultValues true} constraint of this module's unit tests.</p>
+ */
+public class BlobDescriptorBackupTest {
+
+    private static final long EXPORTED_AT = 1753900000000L;
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    private static BlobDescriptor descriptor(String id, String slobId, String blobId,
+                                             String key, String fragment) {
+        BlobDescriptor descriptor = new BlobDescriptor();
+        descriptor.id = id;
+        descriptor.createdAt = 1000L;
+        descriptor.lastAccess = 2000L;
+        descriptor.slobId = slobId;
+        descriptor.slobUri = "content://dict/" + slobId;
+        descriptor.blobId = blobId;
+        descriptor.key = key;
+        descriptor.fragment = fragment;
+        return descriptor;
+    }
+
+    private byte[] write(List<BlobDescriptor> bookmarks, List<BlobDescriptor> history) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BlobDescriptorBackup.write(out, mapper, bookmarks, history, EXPORTED_AT);
+        return out.toByteArray();
+    }
+
+    private static InputStream stream(String json) {
+        return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ── write / read round trip ──────────────────────────────────────────────
+
+    @Test
+    public void roundTripKeepsBothListsAndEveryField() throws IOException {
+        BlobDescriptor bookmark = descriptor("bookmark-1", "dict-a", "blob-1", "hello", "top");
+        BlobDescriptor visited = descriptor("history-1", "dict-b", "blob-2", "world", null);
+
+        byte[] backup = write(Collections.singletonList(bookmark), Collections.singletonList(visited));
+        BlobDescriptorBackup.Content content =
+                BlobDescriptorBackup.read(new ByteArrayInputStream(backup), mapper);
+
+        assertEquals(1, content.bookmarks.size());
+        assertEquals(1, content.history.size());
+
+        BlobDescriptor readBookmark = content.bookmarks.get(0);
+        assertEquals("bookmark-1", readBookmark.id);
+        assertEquals(1000L, readBookmark.createdAt);
+        assertEquals(2000L, readBookmark.lastAccess);
+        assertEquals("dict-a", readBookmark.slobId);
+        assertEquals("content://dict/dict-a", readBookmark.slobUri);
+        assertEquals("blob-1", readBookmark.blobId);
+        assertEquals("hello", readBookmark.key);
+        assertEquals("top", readBookmark.fragment);
+
+        BlobDescriptor readVisited = content.history.get(0);
+        assertEquals("world", readVisited.key);
+        assertNull("null fragment must stay null", readVisited.fragment);
+    }
+
+    @Test
+    public void writtenFileCarriesFormatMarkerAndVersion() throws IOException {
+        String json = new String(write(Collections.emptyList(), Collections.emptyList()),
+                StandardCharsets.UTF_8);
+        assertTrue(json, json.contains("\"format\":\"" + BlobDescriptorBackup.FORMAT + "\""));
+        assertTrue(json, json.contains("\"version\":" + BlobDescriptorBackup.VERSION));
+        assertTrue(json, json.contains("\"exportedAt\":" + EXPORTED_AT));
+    }
+
+    @Test
+    public void readsEmptyListsWhenNothingWasExported() throws IOException {
+        BlobDescriptorBackup.Content content = BlobDescriptorBackup.read(
+                new ByteArrayInputStream(write(Collections.emptyList(), Collections.emptyList())), mapper);
+        assertTrue(content.bookmarks.isEmpty());
+        assertTrue(content.history.isEmpty());
+    }
+
+    // ── read rejects what is not our file ────────────────────────────────────
+
+    @Test(expected = IOException.class)
+    public void readRejectsForeignFormat() throws IOException {
+        BlobDescriptorBackup.read(stream("{\"format\":\"something-else\",\"version\":1}"), mapper);
+    }
+
+    @Test(expected = IOException.class)
+    public void readRejectsMissingFormat() throws IOException {
+        BlobDescriptorBackup.read(stream("{\"version\":1,\"bookmarks\":[]}"), mapper);
+    }
+
+    @Test(expected = IOException.class)
+    public void readRejectsFutureVersion() throws IOException {
+        BlobDescriptorBackup.read(stream("{\"format\":\"" + BlobDescriptorBackup.FORMAT
+                + "\",\"version\":" + (BlobDescriptorBackup.VERSION + 1) + "}"), mapper);
+    }
+
+    @Test(expected = IOException.class)
+    public void readRejectsNonJsonContent() throws IOException {
+        BlobDescriptorBackup.read(stream("this is not json at all"), mapper);
+    }
+
+    @Test(expected = IOException.class)
+    public void readRejectsJsonArray() throws IOException {
+        BlobDescriptorBackup.read(stream("[]"), mapper);
+    }
+
+    @Test
+    public void readSkipsEntriesWithoutDictionaryOrKey() throws IOException {
+        String json = "{\"format\":\"" + BlobDescriptorBackup.FORMAT + "\",\"version\":1,"
+                + "\"bookmarks\":["
+                + "{\"id\":\"a\",\"slobId\":\"dict-a\",\"key\":\"hello\"},"
+                + "{\"id\":\"b\",\"key\":\"no dictionary\"},"
+                + "{\"id\":\"c\",\"slobId\":\"dict-a\"}"
+                + "],\"history\":[]}";
+        BlobDescriptorBackup.Content content = BlobDescriptorBackup.read(stream(json), mapper);
+        assertEquals(1, content.bookmarks.size());
+        assertEquals("hello", content.bookmarks.get(0).key);
+    }
+
+    // ── selectNew (merge, skip duplicates) ───────────────────────────────────
+
+    @Test
+    public void selectNewKeepsEntriesNotAlreadyPresent() {
+        List<BlobDescriptor> existing = Collections.singletonList(
+                descriptor("existing-1", "dict-a", "blob-1", "hello", null));
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("imported-1", "dict-a", "blob-9", "goodbye", null));
+
+        List<BlobDescriptor> accepted = BlobDescriptorBackup.selectNew(existing, imported);
+
+        assertEquals(1, accepted.size());
+        assertEquals("goodbye", accepted.get(0).key);
+        assertEquals("id must be kept when free", "imported-1", accepted.get(0).id);
+    }
+
+    @Test
+    public void selectNewSkipsExactDuplicates() {
+        List<BlobDescriptor> existing = Collections.singletonList(
+                descriptor("existing-1", "dict-a", "blob-1", "hello", "top"));
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("imported-1", "dict-a", "blob-1", "hello", "top"));
+
+        assertTrue(BlobDescriptorBackup.selectNew(existing, imported).isEmpty());
+    }
+
+    @Test
+    public void selectNewSkipsSameKeyInSameDictionaryWithDifferentBlobId() {
+        List<BlobDescriptor> existing = Collections.singletonList(
+                descriptor("existing-1", "dict-a", "blob-1", "hello", null));
+        // Same word, same dictionary, but the dictionary file was rebuilt: new blob id.
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("imported-1", "dict-a", "blob-42", "hello", null));
+
+        assertTrue(BlobDescriptorBackup.selectNew(existing, imported).isEmpty());
+    }
+
+    @Test
+    public void selectNewKeepsSameKeyFromAnotherDictionary() {
+        List<BlobDescriptor> existing = Collections.singletonList(
+                descriptor("existing-1", "dict-a", "blob-1", "hello", null));
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("imported-1", "dict-b", "blob-1", "hello", null));
+
+        assertEquals(1, BlobDescriptorBackup.selectNew(existing, imported).size());
+    }
+
+    @Test
+    public void selectNewDedupesWithinImportedBatch() {
+        List<BlobDescriptor> imported = Arrays.asList(
+                descriptor("imported-1", "dict-a", "blob-1", "hello", null),
+                descriptor("imported-2", "dict-a", "blob-1", "hello", null));
+
+        List<BlobDescriptor> accepted = BlobDescriptorBackup.selectNew(new ArrayList<>(), imported);
+
+        assertEquals(1, accepted.size());
+        assertEquals("imported-1", accepted.get(0).id);
+    }
+
+    @Test
+    public void selectNewReplacesIdCollidingWithExistingEntry() {
+        List<BlobDescriptor> existing = Collections.singletonList(
+                descriptor("same-id", "dict-a", "blob-1", "hello", null));
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("same-id", "dict-b", "blob-2", "goodbye", null));
+
+        List<BlobDescriptor> accepted = BlobDescriptorBackup.selectNew(existing, imported);
+
+        assertEquals(1, accepted.size());
+        assertNotEquals("id would overwrite the stored entry file", "same-id", accepted.get(0).id);
+        assertNotNull(accepted.get(0).id);
+    }
+
+    @Test
+    public void selectNewAssignsIdWhenMissing() {
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor(null, "dict-a", "blob-1", "hello", null));
+
+        List<BlobDescriptor> accepted = BlobDescriptorBackup.selectNew(new ArrayList<>(), imported);
+
+        assertEquals(1, accepted.size());
+        assertNotNull(accepted.get(0).id);
+        assertFalse(accepted.get(0).id.isEmpty());
+    }
+
+    @Test
+    public void selectNewLeavesExistingListUntouched() {
+        List<BlobDescriptor> existing = new ArrayList<>(Collections.singletonList(
+                descriptor("existing-1", "dict-a", "blob-1", "hello", null)));
+        List<BlobDescriptor> imported = Collections.singletonList(
+                descriptor("imported-1", "dict-b", "blob-2", "goodbye", null));
+
+        BlobDescriptorBackup.selectNew(existing, imported);
+
+        assertEquals(1, existing.size());
+        assertEquals("existing-1", existing.get(0).id);
+    }
+}


### PR DESCRIPTION
## Summary

- New **Backup** section in Settings with Export / Import, so bookmarks and history survive a move to another device.
- Export writes a single JSON file through the system file picker (default name `oss-dict-backup.json`), holding both lists with the same field names `DescriptorStore` already persists.
- Import **merges**: entries already present are skipped (exact match, or same key in the same dictionary), nothing is replaced or removed, and a file that is not a backup fails with a message instead of touching the lists. IDs colliding with stored entries are regenerated, since they are store file names.
- Bookmarks are no longer capped at 100 — they are user curated and a restore must not silently drop entries. History keeps its cap, now trimmed in a loop since an import can overflow it by more than one.

## Testing

- `./gradlew assembleDebug` — compiles.
- `./gradlew :testDebugUnitTest --tests 'itkach.aard2.descriptor.BlobDescriptorBackupTest'` — 17 new tests green (format round-trip, rejects foreign/newer/malformed files, merge and ID rules). Mutation-smoked. Pre-existing dictionary tests stay red on `master` (`Slob$Strength`), unchanged by this PR.
- `./gradlew lint` — only new issues are `MissingTranslation` for the 9 new English strings (Weblate-managed) and two `PluralsCandidate` warnings of the same shape as the existing `notification_scan_completed_both`.
- Run on emulator (API 36): export produced a valid file; re-importing it added 0 entries; importing a file with one new bookmark and one new history entry added exactly those two, both visible in their tabs; importing a ZIP showed the error message with no crash and left the stores untouched.

Fixes #35