### PR TITLE
fix(article): wait for dictionaries to load before intent lookups

### DIFF
--- a/src/itkach/aard2/SlobHelper.java
+++ b/src/itkach/aard2/SlobHelper.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import itkach.aard2.descriptor.BlobDescriptor;
 import itkach.aard2.descriptor.BlobDescriptorBackup;
@@ -90,6 +92,8 @@ public final class SlobHelper {
     private volatile int port = -1;
     private volatile boolean initialized;
     private volatile boolean serverBlocked;
+    /** Opens once {@link #init()} is done loading, see {@link #awaitInitialized(long)}. */
+    private final CountDownLatch initLatch = new CountDownLatch(1);
 
     private SlobHelper(@NonNull Application application) {
         this.application = application;
@@ -107,16 +111,47 @@ public final class SlobHelper {
         random = new Random();
     }
 
+    /**
+     * Loads dictionaries, bookmarks and history and starts the embedded server.
+     *
+     * <p>{@code initialized} is raised up front on purpose: {@link #updateSlobs()} runs
+     * synchronously from within {@link #dictionaries}{@code .load()} (through the data set
+     * observer) and calls {@link #checkInitialized()}. Readiness for lookups is therefore
+     * published separately, through {@link #awaitInitialized(long)}.</p>
+     */
     @WorkerThread
     public void init() {
         if (initialized) {
             return;
         }
         initialized = true;
-        ensureServerStarted();
-        dictionaries.load();
-        bookmarks.load();
-        history.load();
+        try {
+            ensureServerStarted();
+            dictionaries.load();
+            bookmarks.load();
+            history.load();
+        } finally {
+            initLatch.countDown();
+        }
+    }
+
+    /**
+     * Blocks until {@link #init()} has finished loading. Callers that come straight from an
+     * external intent (see {@code ArticleCollectionViewModel}) would otherwise search an empty
+     * dictionary set on a cold start and report the article as missing.
+     *
+     * @param timeoutMillis how long to wait before giving up
+     * @return true when loading completed, false on timeout or interruption
+     */
+    @WorkerThread
+    public boolean awaitInitialized(long timeoutMillis) {
+        try {
+            return initLatch.await(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.w(TAG, "Interrupted while waiting for initialization", e);
+            return false;
+        }
     }
 
     /**

--- a/src/itkach/aard2/article/ArticleCollectionViewModel.java
+++ b/src/itkach/aard2/article/ArticleCollectionViewModel.java
@@ -32,6 +32,11 @@ import itkach.slob.Slob;
 
 public class ArticleCollectionViewModel extends AndroidViewModel {
     public static final String TAG = ArticleCollectionViewModel.class.getSimpleName();
+    /**
+     * How long a lookup waits for dictionaries to finish loading. Only ever reached on a cold
+     * start triggered by an external intent, where this activity runs before loading is done.
+     */
+    private static final long INIT_TIMEOUT_MS = 20_000L;
     private final itkach.aard2.Application application;
     private final MutableLiveData<BlobListWrapper> blobListLiveData = new MutableLiveData<>();
     private final MutableLiveData<CharSequence> failureMessageLiveData = new MutableLiveData<>();
@@ -74,6 +79,10 @@ public class ArticleCollectionViewModel extends AndroidViewModel {
         ThreadUtils.postOnBackgroundThread(() -> {
             articleUri = intent.getData();
             int currentPosition = intent.getIntExtra("position", 0);
+            if (!SlobHelper.getInstance().awaitInitialized(INIT_TIMEOUT_MS)) {
+                // Search anyway with whatever loaded so far: no worse than failing outright.
+                Log.w(TAG, String.format("Dictionaries still loading after %d ms", INIT_TIMEOUT_MS));
+            }
             try {
                 BlobListWrapper result;
                 if (articleUri != null) {
@@ -92,12 +101,12 @@ public class ArticleCollectionViewModel extends AndroidViewModel {
                 }
                 if (result != null) {
                     int resultCount = result.size();
-                    if (resultCount != 0) {
-                        blobListLiveData.postValue(result);
+                    if (resultCount == 0) {
+                        failureMessageLiveData.postValue(application.getString(R.string.article_collection_nothing_found));
                     } else if (currentPosition >= resultCount) {
                         failureMessageLiveData.postValue(application.getString(R.string.article_collection_selected_not_available));
                     } else {
-                        failureMessageLiveData.postValue(application.getString(R.string.article_collection_nothing_found));
+                        blobListLiveData.postValue(result);
                     }
                 } else {
                     failureMessageLiveData.postValue(application.getString(R.string.article_collection_invalid_link));


### PR DESCRIPTION
## Summary

- External intents (`PROCESS_TEXT`, `SEND`, `aard2.lookup`) start `ArticleCollectionActivity` directly, bypassing `MainActivity`. On a cold start the lookup therefore ran concurrently with `SlobHelper.init()` on the shared thread pool and searched an empty dictionary set — the user got "Selected article is not available" and had to retry.
- `SlobHelper` now publishes readiness through a `CountDownLatch` (`awaitInitialized`), counted down in a `finally` so a failed load can't strand waiters. `initialized` stays raised up front because `updateSlobs()` runs synchronously inside `dictionaries.load()` and asserts on it.
- `ArticleCollectionViewModel` waits on that latch (20s cap) before searching. Timing out falls through and searches whatever loaded — no worse than today, and the existing loading layout covers the wait.
- Unswapped the two failure branches in the same method: an empty result always reported "selected article is not available" while "nothing found" was unreachable, and the out-of-range `position` check never ran.

Note this is not a 2.0.2 regression — `init()` has the same early-flag structure back in `v2.0.1`. Loading simply got slower (MDict/StarDict, auto-load folder), which widened the window.

## Testing

`./gradlew assembleDebug` compiles; `./gradlew lint` reports no new issue over the `master` baseline. Unit tests untouched — they only cover `dictionary/` parsing and the suite is already red on `master`.

Verified on an emulator with two test dictionaries loaded:

- Cold-start `PROCESS_TEXT` lookup of a known word opens the article on the first try.
- With a temporary 6s delay injected into `init()`: loading screen at 3s, article at 11s — the latch holds.
- Same delay with the wait disabled (control): the activity closes immediately, reproducing the reported bug.
- A word absent from every dictionary now toasts "Nothing found" instead of "Selected article is not available".

Still worth a check on a real device with a large dictionary set, where the window is naturally wide.

Fixes #90