### PR TITLE
fix(widget): keep horizontal scroll and pinch zoom in the article view

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -181,6 +181,8 @@
     <string name="setting_enable_force_dark_web_view">Enable force dark in WebView in dark mode</string>
     <string name="setting_disable_javascript_title">Disable JavaScript</string>
     <string name="setting_disable_javascript_subtitle">Disabling JavaScript has unintended side effects such as applying custom styles and loading remote contents.</string>
+    <string name="setting_disable_swipe_navigation_title">Disable swipe to change article</string>
+    <string name="setting_disable_swipe_navigation_subtitle">Keeps horizontal swipes for scrolling wide content. Articles can still be changed from the tabs.</string>
     <string name="specified_number_of_items_selected">%d selected</string>
     <string name="action_open_random_article">Random article</string>
     <string name="setting_disable_history">Disable history</string>

--- a/src/itkach/aard2/article/ArticleCollectionActivity.java
+++ b/src/itkach/aard2/article/ArticleCollectionActivity.java
@@ -56,6 +56,7 @@ import itkach.aard2.SlobHelper;
 import itkach.aard2.dictionary.DictionaryEntry;
 import itkach.aard2.prefs.AppPrefs;
 import itkach.aard2.prefs.ArticleCollectionPrefs;
+import itkach.aard2.prefs.ArticleViewPrefs;
 import itkach.aard2.utils.ThreadUtils;
 import itkach.aard2.utils.Utils;
 import itkach.aard2.widget.ArticleWebView;
@@ -107,6 +108,7 @@ public class ArticleCollectionActivity extends AppCompatActivity
 
             viewPager = findViewById(R.id.pager);
             viewPager.setNestedScrollingEnabled(true);
+            applySwipeNavigationPref();
             pagerAdapter = new ArticleCollectionPagerAdapter(blobListWrapper, this);
             viewPager.setAdapter(pagerAdapter);
             TabLayoutMediator tabLayoutMediator = new TabLayoutMediator(tabs, viewPager, true, (tab, position1) -> tab.setText(pagerAdapter.getPageTitle(position1)));
@@ -244,6 +246,12 @@ public class ArticleCollectionActivity extends AppCompatActivity
         }
     }
 
+    private void applySwipeNavigationPref() {
+        if (viewPager != null) {
+            viewPager.setUserInputEnabled(!ArticleViewPrefs.disableSwipeNavigation());
+        }
+    }
+
     SharedPreferences prefs() {
         return getSharedPreferences("articleCollection", Activity.MODE_PRIVATE);
     }
@@ -257,6 +265,7 @@ public class ArticleCollectionActivity extends AppCompatActivity
         super.onResume();
         Log.d(TAG, "[F] Resume");
         applyFullScreenPref();
+        applySwipeNavigationPref();
         prefs().registerOnSharedPreferenceChangeListener(this);
     }
 

--- a/src/itkach/aard2/prefs/ArticleViewPrefs.java
+++ b/src/itkach/aard2/prefs/ArticleViewPrefs.java
@@ -48,6 +48,14 @@ public class ArticleViewPrefs extends Prefs {
         getInstance().prefs.edit().putBoolean("disable_js", disableJavaScript).apply();
     }
 
+    public static boolean disableSwipeNavigation() {
+        return getInstance().prefs.getBoolean("disable_swipe_nav", false);
+    }
+
+    public static void setDisableSwipeNavigation(boolean disableSwipeNavigation) {
+        getInstance().prefs.edit().putBoolean("disable_swipe_nav", disableSwipeNavigation).apply();
+    }
+
     public static int getPreferredZoomLevel() {
         return getInstance().prefs.getInt(PREF_TEXT_ZOOM, 100);
     }

--- a/src/itkach/aard2/prefs/SettingsListAdapter.java
+++ b/src/itkach/aard2/prefs/SettingsListAdapter.java
@@ -80,6 +80,7 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
     private static final long ID_DISABLE_JS           = 501;
     private static final long ID_USER_STYLES          = 502;
     private static final long ID_CLEAR_CACHE          = 503;
+    private static final long ID_DISABLE_SWIPE_NAV    = 504;
 
     private static final long ID_SORT_BY_RANK         = 601;
     private static final long ID_AUTO_PASTE           = 602;
@@ -280,6 +281,12 @@ public class SettingsListAdapter extends RecyclerView.Adapter<SettingsListAdapte
                 new BoolPref() {
                     @Override public boolean get() { return ArticleViewPrefs.disableJavaScript(); }
                     @Override public void set(boolean v) { ArticleViewPrefs.setDisableJavaScript(v); }
+                }));
+        list.add(new SwitchItem(ID_DISABLE_SWIPE_NAV, R.string.setting_disable_swipe_navigation_title,
+                R.string.setting_disable_swipe_navigation_subtitle,
+                new BoolPref() {
+                    @Override public boolean get() { return ArticleViewPrefs.disableSwipeNavigation(); }
+                    @Override public void set(boolean v) { ArticleViewPrefs.setDisableSwipeNavigation(v); }
                 }));
         list.add(new UserStylesItem());
         list.add(new ClearCacheItem());

--- a/src/itkach/aard2/widget/NestedScrollWebView.java
+++ b/src/itkach/aard2/widget/NestedScrollWebView.java
@@ -17,6 +17,8 @@ class NestedScrollWebView extends WebView implements NestedScrollingChild {
     private int lastMotionX = 0;
     private int lastMotionY = 0;
 
+    private boolean multiTouch = false;
+
     private int[] scrollOffset = new int[2];
     private int[] scrollConsumed = new int[2];
 
@@ -38,71 +40,101 @@ class NestedScrollWebView extends WebView implements NestedScrollingChild {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        boolean result = false;
-
-        MotionEvent trackedEvent = MotionEvent.obtain(event);
-
         int action = event.getActionMasked();
-
-        if (action == MotionEvent.ACTION_DOWN) {
-            nestedOffsetY = 0;
-        }
-
-        float x = event.getX();
-        float y = event.getY();
-
-        event.offsetLocation(0f, nestedOffsetY);
 
         switch (action) {
             case MotionEvent.ACTION_DOWN: {
-                lastMotionX = (int) x;
-                lastMotionY = (int) y;
-                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL);
-                result = super.onTouchEvent(event);
-                break;
-            }
-            case MotionEvent.ACTION_MOVE : {
-                int deltaY = (int) (lastMotionY - y);
-
-                if (Math.abs(deltaY) > Math.abs(lastMotionX - x) &&
-                        (canScrollVertically(1) || canScrollVertically(-1))
-                ) {
+                nestedOffsetY = 0;
+                multiTouch = false;
+                lastMotionX = (int) event.getX();
+                lastMotionY = (int) event.getY();
+                // A quick horizontal swipe passes the parent's touch slop on the very
+                // first move, and ViewGroup lets the parent intercept before that move
+                // reaches this view. Claim the gesture up front whenever the content can
+                // scroll sideways at all; onSinglePointerMove releases it again as soon
+                // as the direction is known and the pager should get the gesture.
+                if (canScrollHorizontally(1) || canScrollHorizontally(-1)) {
                     requestDisallowInterceptTouchEvent(true);
                 }
-
-                if (dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
-                    deltaY -= scrollConsumed[1];
-                    trackedEvent.offsetLocation(0f, scrollOffset[1]);
-                    nestedOffsetY += scrollOffset[1];
-                }
-
-                lastMotionY = (int) (y - scrollOffset[1]);
-
-                int oldY = getScrollY();
-                int newScrollY = Math.max(0, oldY + deltaY);
-                int dyConsumed = newScrollY - oldY;
-                int dyUnconsumed = deltaY - dyConsumed;
-
-                if (dispatchNestedScroll(0, dyConsumed, 0, dyUnconsumed, scrollOffset)) {
-                    lastMotionY -= scrollOffset[1];
-                    trackedEvent.offsetLocation(0f, scrollOffset[1]);
-                    nestedOffsetY += scrollOffset[1];
-                }
-
-                result = super.onTouchEvent(trackedEvent);
-                trackedEvent.recycle();
-                break;
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL);
+                return superTouchWithNestedOffset(event);
             }
-            case MotionEvent.ACTION_POINTER_DOWN:
+            case MotionEvent.ACTION_POINTER_DOWN: {
+                // Pinch zoom: the whole gesture belongs to the WebView, so keep the parent
+                // (ViewPager2) from stealing it until every finger is up.
+                multiTouch = true;
+                stopNestedScroll();
+                requestDisallowInterceptTouchEvent(true);
+                return superTouchWithNestedOffset(event);
+            }
+            case MotionEvent.ACTION_MOVE: {
+                if (multiTouch) {
+                    return superTouchWithNestedOffset(event);
+                }
+                return onSinglePointerMove(event);
+            }
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL: {
+                multiTouch = false;
                 stopNestedScroll();
                 requestDisallowInterceptTouchEvent(false);
-                result = super.onTouchEvent(event);
-                break;
+                return superTouchWithNestedOffset(event);
             }
+            default:
+                // Everything else (ACTION_POINTER_UP in particular) must reach the WebView,
+                // otherwise its gesture detectors never see the gesture end.
+                return superTouchWithNestedOffset(event);
         }
-        return result;
+    }
+
+    private boolean superTouchWithNestedOffset(MotionEvent event) {
+        event.offsetLocation(0f, nestedOffsetY);
+        return super.onTouchEvent(event);
+    }
+
+    private boolean onSinglePointerMove(MotionEvent event) {
+        float x = event.getX();
+        float y = event.getY();
+
+        int deltaX = (int) (lastMotionX - x);
+        int deltaY = (int) (lastMotionY - y);
+
+        if (Math.abs(deltaY) > Math.abs(deltaX)) {
+            if (canScrollVertically(1) || canScrollVertically(-1)) {
+                requestDisallowInterceptTouchEvent(true);
+            }
+        } else if (deltaX != 0) {
+            // Horizontal drag: keep it while the content can still scroll that way,
+            // hand it back to the pager once this edge is reached.
+            requestDisallowInterceptTouchEvent(canScrollHorizontally(deltaX > 0 ? 1 : -1));
+        }
+
+        MotionEvent trackedEvent = MotionEvent.obtain(event);
+        try {
+            if (dispatchNestedPreScroll(0, deltaY, scrollConsumed, scrollOffset)) {
+                deltaY -= scrollConsumed[1];
+                trackedEvent.offsetLocation(0f, scrollOffset[1]);
+                nestedOffsetY += scrollOffset[1];
+            }
+
+            lastMotionX = (int) x;
+            lastMotionY = (int) (y - scrollOffset[1]);
+
+            int oldY = getScrollY();
+            int newScrollY = Math.max(0, oldY + deltaY);
+            int dyConsumed = newScrollY - oldY;
+            int dyUnconsumed = deltaY - dyConsumed;
+
+            if (dispatchNestedScroll(0, dyConsumed, 0, dyUnconsumed, scrollOffset)) {
+                lastMotionY -= scrollOffset[1];
+                trackedEvent.offsetLocation(0f, scrollOffset[1]);
+                nestedOffsetY += scrollOffset[1];
+            }
+
+            return super.onTouchEvent(trackedEvent);
+        } finally {
+            trackedEvent.recycle();
+        }
     }
 
     @Override

--- a/tools/gen_sample_stardict.py
+++ b/tools/gen_sample_stardict.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate sample uncompressed StarDict dictionaries for OSS-Dict manual testing.
+
+Targets issue #32 (horizontal scroll / pinch zoom in the article view):
+entries deliberately contain content wider than the viewport, plus a narrow
+control article. Two dictionaries share the same keys so a lookup opens
+several pager tabs — needed to test swipe-to-change-article.
+
+Output: <outdir>/scroll-test-{a,b}.{ifo,idx,dict} plus scroll-test-{a,b}.zip
+
+Import the .zip files in the app: loading a loose .ifo from a SAF folder is
+broken app-side (findCompanionFile uses DocumentFile.fromSingleUri, whose
+getParentFile() is always null, so the .idx is never found).
+"""
+
+import os
+import struct
+import sys
+import zipfile
+
+ELEMENTS = [
+    ("H", "He"), ("Li", "Be"), ("Na", "Mg"), ("K", "Ca"), ("Rb", "Sr"),
+    ("Cs", "Ba"), ("Fr", "Ra"),
+]
+GROUPS = 18
+
+CSS = """
+<style>
+ body { font-family: sans-serif; margin: 8px; }
+ table.pt { border-collapse: collapse; }
+ table.pt td { border: 1px solid #888; width: 64px; min-width: 64px;
+               height: 48px; text-align: center; font-size: 14px; }
+ pre.wide { background: #f0f0f0; padding: 6px; }
+ .strip { width: 2400px; height: 40px;
+          background: linear-gradient(90deg, #f00, #0f0, #00f); }
+</style>
+"""
+
+
+def periodic_table(variant):
+    rows = []
+    for period, (left, right) in enumerate(ELEMENTS, start=1):
+        cells = []
+        for group in range(1, GROUPS + 1):
+            if group == 1:
+                cells.append(f"<td><b>{left}</b><br>{period}</td>")
+            elif group == GROUPS:
+                cells.append(f"<td><b>{right}</b><br>{period}</td>")
+            else:
+                cells.append(f"<td>{period}.{group}</td>")
+        rows.append("<tr>" + "".join(cells) + "</tr>")
+    header = "<tr>" + "".join(f"<td><b>G{g}</b></td>" for g in range(1, GROUPS + 1)) + "</tr>"
+    return (
+        f"{CSS}<h1>Periodic table ({variant})</h1>"
+        "<p>Table is ~18 x 64px wide, so it overflows any phone viewport. "
+        "Drag horizontally: the article must scroll, not switch to the next tab. "
+        "At the left/right edge a further swipe changes article.</p>"
+        f"<table class='pt'>{header}{''.join(rows)}</table>"
+        "<p>Scroll down, then pinch to zoom in and out: the zoom level must hold "
+        "when the fingers are lifted.</p>"
+        + "".join(f"<p>Filler line {i} to make the page tall enough to scroll "
+                  "vertically as well.</p>" for i in range(1, 41))
+    )
+
+
+def wide_code(variant):
+    long_line = " ".join(f"token_{i}" for i in range(1, 121))
+    return (
+        f"{CSS}<h1>Wide code ({variant})</h1>"
+        "<p>A single unwrapped line inside &lt;pre&gt;.</p>"
+        f"<pre class='wide'>{long_line}</pre>"
+        "<p>Below is a fixed 2400px wide block:</p>"
+        "<div class='strip'></div>"
+    )
+
+
+def narrow(variant):
+    return (
+        f"{CSS}<h1>Narrow control ({variant})</h1>"
+        "<p>Nothing here is wider than the viewport, so a horizontal swipe must "
+        "still change article — this is the control case for issue #32.</p>"
+        + "".join(f"<p>Paragraph {i}.</p>" for i in range(1, 31))
+    )
+
+
+def zoom(variant):
+    sizes = "".join(
+        f"<p style='font-size:{size}px'>Pinch zoom sample at {size}px.</p>"
+        for size in (10, 14, 20, 28, 40)
+    )
+    return (
+        f"{CSS}<h1>Zoom ({variant})</h1>"
+        "<p>Pinch in and out repeatedly, lifting one finger before the other. "
+        "The page must keep the zoom level instead of snapping to minimum.</p>"
+        + sizes
+    )
+
+
+ARTICLES = [
+    ("periodic table", periodic_table),
+    ("wide code", wide_code),
+    ("narrow control", narrow),
+    ("zoom", zoom),
+]
+
+
+def write_dictionary(outdir, base, bookname, variant):
+    entries = []
+    dict_blob = bytearray()
+    for key, builder in ARTICLES:
+        body = builder(variant).encode("utf-8")
+        entries.append((key, len(dict_blob), len(body)))
+        dict_blob += body
+
+    # .idx: null-terminated UTF-8 key + 4-byte BE offset + 4-byte BE size,
+    # sorted by raw key bytes as the StarDict spec requires.
+    idx = bytearray()
+    for key, offset, size in sorted(entries, key=lambda item: item[0].encode("utf-8")):
+        idx += key.encode("utf-8") + b"\x00" + struct.pack(">II", offset, size)
+
+    ifo = (
+        "StarDict's dict ifo file\n"
+        "version=2.4.2\n"
+        f"bookname={bookname}\n"
+        f"wordcount={len(entries)}\n"
+        f"idxfilesize={len(idx)}\n"
+        "sametypesequence=h\n"
+        "description=Sample dictionary for OSS-Dict issue #32 (horizontal scroll and zoom)\n"
+    )
+
+    os.makedirs(outdir, exist_ok=True)
+    ifo_path = os.path.join(outdir, base + ".ifo")
+    idx_path = os.path.join(outdir, base + ".idx")
+    dict_path = os.path.join(outdir, base + ".dict")
+    with open(ifo_path, "w", encoding="utf-8") as handle:
+        handle.write(ifo)
+    with open(idx_path, "wb") as handle:
+        handle.write(idx)
+    with open(dict_path, "wb") as handle:
+        handle.write(dict_blob)
+
+    with zipfile.ZipFile(os.path.join(outdir, base + ".zip"), "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in (ifo_path, idx_path, dict_path):
+            archive.write(path, os.path.basename(path))
+
+    return len(entries), len(idx), len(dict_blob)
+
+
+def main():
+    outdir = sys.argv[1] if len(sys.argv) > 1 else os.path.dirname(os.path.abspath(__file__))
+    for base, bookname, variant in (
+        ("scroll-test-a", "Scroll Test A", "A"),
+        ("scroll-test-b", "Scroll Test B", "B"),
+    ):
+        words, idx_size, dict_size = write_dictionary(outdir, base, bookname, variant)
+        print(f"{base}: {words} entries, idx {idx_size} B, dict {dict_size} B -> {outdir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Horizontal drags on content wider than the viewport now scroll the article instead of the pager changing article. The WebView claims the gesture on touch down when its content can scroll sideways, and hands it back once that horizontal edge is reached — a swipe at the edge still changes article.
- Pinch zoom no longer snaps back to minimum: multi-touch keeps the gesture until every finger is up, and `ACTION_POINTER_UP` reaches the WebView instead of being swallowed by a switch with no matching branch.
- New Article view setting, *Disable swipe to change article*, for pages whose scrollable element is an inner `overflow-x` container — `WebView.canScrollHorizontally` only sees the page-level scroll range, so those still lose the swipe otherwise.
- Adds `tools/gen_sample_stardict.py`, which builds small StarDict dictionaries with deliberately over-wide articles for manual testing.

## Testing

- `./gradlew assembleDebug` compiles; `./gradlew lint` shows no new issue (report totals unchanged, remaining errors are the pre-existing `MissingTranslation` set).
- Ran on an emulator with the generated sample dictionaries: a fast horizontal swipe scrolls the wide table and stays on the same article; at the horizontal edge the next swipe changes article; vertical scrolling and narrow articles behave as before.
- Pinch zoom was checked by hand on device, not by synthetic input — worth a second pass by a reviewer.

Fixes #32