### PR TITLE
feat(lookup): add launcher shortcut to look up a word

### DIFF
--- a/AndroidManifest.template.xml
+++ b/AndroidManifest.template.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="stateHidden"
             android:exported="true">
             <intent-filter>
@@ -49,6 +50,10 @@
                 <data android:host="en.m.wikipedia.org" />
                 <data android:host="en.wikipedia.org" />
             </intent-filter>
+
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="stateHidden"
             android:exported="true">
             <intent-filter>
@@ -49,6 +50,10 @@
                 <data android:host="en.m.wikipedia.org" />
                 <data android:host="en.wikipedia.org" />
             </intent-filter>
+
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity

--- a/res/drawable/ic_shortcut_search.xml
+++ b/res/drawable/ic_shortcut_search.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+    Launcher shortcut icon. Inflated by the launcher process, so it must not use
+    theme attributes (unlike ic_search.xml) and carries its own badge background:
+    some launchers draw legacy shortcut icons without one.
+-->
+<vector android:height="48dp"
+    android:viewportHeight="48"
+    android:viewportWidth="48"
+    android:width="48dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M24,0A24,24 0 1,0 24,48A24,24 0 1,0 24,0z" />
+    <group
+        android:scaleX="1.25"
+        android:scaleY="1.25"
+        android:translateX="9"
+        android:translateY="9">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+    </group>
+</vector>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="action_sort_by_title">By Title</string>
     <string name="action_sort_by_time">By Time</string>
     <string name="action_lookup">Lookup</string>
+    <string name="shortcut_lookup_short_label">Lookup</string>
+    <string name="shortcut_lookup_long_label">Look up a word</string>
     <!--
     English only uses "one" and "other" for plurals.
     Other quantities are included as a fallback if some translation

--- a/res/xml/shortcuts.xml
+++ b/res/xml/shortcuts.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Static launcher shortcuts (API 25+, ignored below that).
+    The intent target cannot reference BuildConfig, hence the literal applicationId.
+-->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <shortcut
+        tools:ignore="UnusedAttribute"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_search"
+        android:shortcutId="lookup"
+        android:shortcutLongLabel="@string/shortcut_lookup_long_label"
+        android:shortcutShortLabel="@string/shortcut_lookup_short_label">
+        <intent
+            android:action="com.akylas.aard2.action.LOOKUP"
+            android:targetClass="itkach.aard2.MainActivity"
+            android:targetPackage="com.akylas.aard2" />
+    </shortcut>
+</shortcuts>

--- a/src/itkach/aard2/MainActivity.java
+++ b/src/itkach/aard2/MainActivity.java
@@ -49,6 +49,12 @@ import itkach.aard2.utils.Utils;
 
 public class MainActivity extends AppCompatActivity implements NavigationBarView.OnItemSelectedListener,
         ViewPager.OnPageChangeListener, SharedPreferences.OnSharedPreferenceChangeListener {
+    /**
+     * Sent by the launcher shortcut declared in res/xml/shortcuts.xml. That file cannot
+     * reference BuildConfig, so the action is spelled out there - keep both in sync.
+     */
+    public static final String ACTION_LOOKUP = BuildConfig.APPLICATION_ID + ".action.LOOKUP";
+
     private static final String TAG = MainActivity.class.getSimpleName();
     private AppSectionsPagerAdapter appSectionsPagerAdapter;
     private AppBarLayout appBarLayout;
@@ -57,6 +63,7 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
     private BottomNavigationView bottomNavigationView;
     private FloatingActionButton fab;
     private int oldPosition = -1;
+    private boolean lookupFocusRequested;
     @Nullable
     private AlertDialog internetPermissionDialog;
 
@@ -135,6 +142,12 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
         } else if (SlobHelper.getInstance().dictionaries.isEmpty()) {
             viewPager.setCurrentItem(3);
         }
+
+        if (savedInstanceState == null) {
+            //Only on a fresh start: getIntent() keeps returning the shortcut intent, so
+            //handling it on a state restore would steal focus again after a process death.
+            handleIntent(getIntent());
+        }
 //        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 //            getWindow().setNavigationBarContrastEnforced(false);
 //        }
@@ -175,6 +188,37 @@ public class MainActivity extends AppCompatActivity implements NavigationBarView
             return WindowInsetsCompat.CONSUMED;
         });
 
+    }
+
+    @Override
+    protected void onNewIntent(@NonNull Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleIntent(intent);
+    }
+
+    /**
+     * Handles the launcher shortcut: shows the lookup tab and asks the lookup fragment to
+     * take focus. The fragment owns the search view, so the request is handed over as a
+     * flag it consumes while its options menu is (re)built.
+     */
+    private void handleIntent(@Nullable Intent intent) {
+        if (intent == null || !ACTION_LOOKUP.equals(intent.getAction())) {
+            return;
+        }
+        lookupFocusRequested = true;
+        viewPager.setCurrentItem(0);
+        viewPager.post(this::invalidateOptionsMenu);
+    }
+
+    /**
+     * Returns whether the lookup fragment should grab focus, clearing the request so that
+     * it only applies once.
+     */
+    public boolean consumeLookupFocusRequest() {
+        boolean requested = lookupFocusRequested;
+        lookupFocusRequested = false;
+        return requested;
     }
 
     @Override

--- a/src/itkach/aard2/lookup/LookupFragment.java
+++ b/src/itkach/aard2/lookup/LookupFragment.java
@@ -1,5 +1,6 @@
 package itkach.aard2.lookup;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -7,6 +8,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -117,13 +119,26 @@ public class LookupFragment extends BaseListFragment implements LookupListener, 
     @Override
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
+        FragmentActivity activity = requireActivity();
+        boolean focusRequested = activity instanceof MainActivity
+                && ((MainActivity) activity).consumeLookupFocusRequest();
         if (AppPrefs.autoPasteInLookup()) {
             CharSequence clipboard = ClipboardUtils.take(requireContext());
             if (clipboard != null && viewModel != null) {
                 searchView.setQuery(clipboard.toString(), false);
                 viewModel.lookup(clipboard.toString());
+                if (focusRequested) {
+                    focusSearch();
+                }
                 return;
             }
+        }
+        if (focusRequested) {
+            //Launcher shortcut: start from an empty field instead of the last query. The
+            //query text listener clears the result list on its own.
+            searchView.setQuery("", false);
+            focusSearch();
+            return;
         }
        // String query = AppPrefs.getLastQuery();
        // searchView.setQuery(query, false);
@@ -131,6 +146,30 @@ public class LookupFragment extends BaseListFragment implements LookupListener, 
        //     viewModel.lookupLastQuery();
        // }
         searchView.setQuery(AppPrefs.getLastQuery(), false);
+    }
+
+    /**
+     * Gives the search view focus and shows the keyboard, overriding both the activity's
+     * stateHidden soft input mode and the clearFocus() done when the "show keyboard on
+     * lookup" preference is off. Posted because the view is not laid out yet while the
+     * options menu is being built.
+     */
+    private void focusSearch() {
+        searchView.requestFocus();
+        searchView.post(() -> {
+            View focused = searchView.findFocus();
+            //The fragment can be detached by the time this runs, for instance when
+            //another tab is selected right after the shortcut launch
+            Context context = getContext();
+            if (focused == null || context == null) {
+                return;
+            }
+            InputMethodManager inputMethodManager =
+                    (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (inputMethodManager != null) {
+                inputMethodManager.showSoftInput(focused, InputMethodManager.SHOW_IMPLICIT);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Static launcher shortcut "Lookup" (`res/xml/shortcuts.xml`, API 25+, no-op below): opens the app on the Lookup tab with an **empty, focused** search field and the keyboard up, instead of resuming on the previous query.
- `MainActivity` gains intent handling — it had none — plus `launchMode="singleTop"`, so the shortcut also lands when the app is already running. It hands a one-shot request to `LookupFragment`, which consumes it while its options menu is built (that's where the `SearchView` lives).
- Own shortcut drawable: `ic_search.xml` uses `?attr/colorControlNormal`, and a shortcut icon is inflated in the *launcher's* process, so it must not carry theme attributes. The drawable includes its own badge background — some launchers don't wrap legacy shortcut icons.
- Auto-paste keeps priority on content: with that preference on, the clipboard is still pasted, the shortcut only adds the focus.

`AndroidManifest.xml` is generated by `./mk-android-manifest` from the template, now that #106 has made the generator reproduce the shipped manifest. The only manifest changes over `master` are `launchMode="singleTop"` and the `android.app.shortcuts` meta-data — verified by comparing the two element trees.

## Testing

`./gradlew assembleDebug` compiles. `./gradlew lint` adds no warning over the baseline; the only new errors are two `MissingTranslation` for the new strings, which Weblate fills like every other string. No unit test: every added line touches `Intent`/`View`/`SearchView`/`InputMethodManager`, and the suite has no Robolectric (it is also red on `master` for an unrelated `Slob$Strength` reason).

Verified on an emulator — `dumpsys shortcut` registers `id=lookup`, and the framework launches it with `NEW_TASK|CLEAR_TASK`:

- app closed → shortcut → Lookup tab, empty field, keyboard shown
- app backgrounded on the Settings tab → shortcut → Lookup tab, field cleared, keyboard shown
- word typed → shortcut → field and result list cleared
- plain launcher tap → previous query still restored, nothing cleared (no regression)

Still worth a manual check:

1. Long-press the app icon: shortcut listed with a legible icon — **especially in KISS**, the launcher from the issue
2. Auto-paste preference on → shortcut still pastes the clipboard, now focused (path not exercised on device)
3. A pinned shortcut survives an app update

Fixes #94