### PR TITLE
build(manifest): make the templates regenerate the shipped manifest

### DIFF
--- a/AndroidManifest.template.xml
+++ b/AndroidManifest.template.xml
@@ -12,17 +12,20 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-sdk tools:overrideLibrary="androidx.webkit" />
 
     <application
         android:name=".Application"
         android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        tools:ignore="UnusedAttribute">
+        tools:ignore="UnusedAttribute"
+        android:largeHeap="true">
 
         <activity
             android:name=".MainActivity"
@@ -34,6 +37,17 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="en.m.wikipedia.org" />
+                <data android:host="en.wikipedia.org" />
             </intent-filter>
         </activity>
 
@@ -68,9 +82,20 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
-        </activity>
-
+            <intent-filter>
+                <action android:name="com.google.android.gms.actions.SEARCH_ACTION" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:mimeType="text/plain" />
+                <data android:scheme="https" />
+            </intent-filter>
 {wikipedia_activities}
+        </activity>
 
         <uses-library
             android:required="false"

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <queries>
         <intent>
-            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <action
+                android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
         </intent>
     </queries>
@@ -13,6 +14,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-sdk tools:overrideLibrary="androidx.webkit" />
+
     <application
         android:name=".Application"
         android:allowBackup="true"
@@ -36,7 +38,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
-                        <intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -46,7 +48,6 @@
                 <data android:scheme="https" />
                 <data android:host="en.m.wikipedia.org" />
                 <data android:host="en.wikipedia.org" />
-                
             </intent-filter>
         </activity>
 
@@ -58,18 +59,22 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="aard2.lookup" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
             <intent-filter>
                 <action android:name="colordict.intent.action.SEARCH" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter>
@@ -114,6 +119,7 @@
                 <data android:host="ar.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -126,7 +132,7 @@
                 <data android:host="de.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
-        
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -139,7 +145,8 @@
                 <data android:host="de.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
-        <intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -151,7 +158,8 @@
                 <data android:host="en.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
-        <intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -163,6 +171,7 @@
                 <data android:host="en.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -175,6 +184,7 @@
                 <data android:host="es.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -187,6 +197,7 @@
                 <data android:host="es.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -199,6 +210,7 @@
                 <data android:host="fa.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -211,6 +223,7 @@
                 <data android:host="fa.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -223,6 +236,7 @@
                 <data android:host="fr.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -235,6 +249,7 @@
                 <data android:host="fr.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -247,6 +262,7 @@
                 <data android:host="it.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -259,6 +275,7 @@
                 <data android:host="it.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -271,6 +288,7 @@
                 <data android:host="ja.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -283,6 +301,7 @@
                 <data android:host="ja.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -295,6 +314,7 @@
                 <data android:host="nl.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -307,6 +327,7 @@
                 <data android:host="nl.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -319,6 +340,7 @@
                 <data android:host="pl.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -331,6 +353,7 @@
                 <data android:host="pl.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -343,6 +366,7 @@
                 <data android:host="pt.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -355,6 +379,7 @@
                 <data android:host="pt.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -367,6 +392,7 @@
                 <data android:host="ru.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -379,6 +405,7 @@
                 <data android:host="ru.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -391,6 +418,7 @@
                 <data android:host="uk.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -403,6 +431,7 @@
                 <data android:host="uk.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -415,6 +444,7 @@
                 <data android:host="zh.wikipedia.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -427,7 +457,9 @@
                 <data android:host="zh.wiktionary.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
+
         </activity>
+
         <uses-library
             android:required="false"
             android:name="com.sec.android.app.multiwindow" />

--- a/wikipedia-activity.template.xml
+++ b/wikipedia-activity.template.xml
@@ -1,8 +1,3 @@
-        <activity-alias
-            android:enabled="false"
-            android:name="{lang}.{project}.org"
-            android:targetActivity=".article.ArticleCollectionActivity"
-            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -15,4 +10,3 @@
                 <data android:host="{lang}.{project}.org" />
                 <data android:pathPrefix="/wiki" />
             </intent-filter>
-        </activity-alias>


### PR DESCRIPTION
## Summary

`AndroidManifest.xml` is documented as generated from `AndroidManifest.template.xml` by `./mk-android-manifest`, but the two had drifted: running the generator rewrote 213 lines and silently dropped shipped configuration.

Lost by a regeneration, before this PR:

- `POST_NOTIFICATIONS` permission, `<uses-sdk tools:overrideLibrary="androidx.webkit">`, `android:largeHeap`, `@mipmap/ic_launcher` (template had `@drawable/`)
- the `en.wikipedia.org` `VIEW` filter on `MainActivity`
- two `ArticleCollectionActivity` filters: `com.google.android.gms.actions.SEARCH_ACTION`, and `VIEW` on `text/plain` + `https`

And the behavioral one: the shipped manifest carries the 28 wikipedia/wiktionary filters **inline and enabled** inside `ArticleCollectionActivity`, while `wikipedia-activity.template.xml` emitted them as `<activity-alias android:enabled="false">` blocks. Regenerating disabled every wikipedia link handler.

This PR ports all of it back into the two templates and commits the regenerated manifest, so the generator is trustworthy again.

## Testing

- Element-tree comparison of the committed manifest against the regenerated one — tags, attributes and order, recursively — is **identical**, with zero elements present on only one side. The only textual difference is whitespace.
- `./gradlew assembleDebug` compiles; `./gradlew lint` issue counts are unchanged from the pre-change baseline.

No runtime behavior changes: this PR makes the tooling reproduce what already ships.

## Note for #105

[#105](https://github.com/Akylas/OSS-Dict/pull/105) had to hand-edit `AndroidManifest.xml` for exactly this reason. Once this merges, that branch can rebase and use `./mk-android-manifest` instead.