### PR TITLE
feat(dictionaries): allow renaming a dictionary

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -39,6 +39,7 @@
     java.lang.String path;
     java.lang.String mddPath;
     java.util.Map tags;
+    java.lang.String displayName;
     boolean active;
     long priority;
     long blobCount;

--- a/res/drawable/ic_edit.xml
+++ b/res/drawable/ic_edit.xml
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<vector android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83l3.75,3.75L20.71,7.04z" />
+</vector>

--- a/res/layout/dialog_rename_dictionary.xml
+++ b/res/layout/dialog_rename_dictionary.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.textfield.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="8dp"
+    android:hint="@string/dictionaries_rename_hint">
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/dictionary_rename_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textCapSentences"
+        android:maxLines="1"
+        android:imeOptions="actionDone" />
+
+</com.google.android.material.textfield.TextInputLayout>

--- a/res/layout/dictionary_list_item.xml
+++ b/res/layout/dictionary_list_item.xml
@@ -85,6 +85,29 @@
                 tools:text="100,000 items" />
 
             <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/dictionary_original_label_row"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginBottom="2dp">
+
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    app:srcCompat="@drawable/ic_edit" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/dictionary_original_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:textAppearance="?attr/textAppearanceListItemSecondary"
+                    tools:text="Original: Wikipedia (en)" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <androidx.appcompat.widget.LinearLayoutCompat
                 android:id="@+id/dictionary_copyright_row"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -202,6 +225,16 @@
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:id="@+id/dictionary_btn_toggle_detail_space" />
+
+            <com.google.android.material.button.MaterialButton
+                style="@style/Widget.Material3.Button.IconButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/dictionary_btn_rename"
+                android:layout_gravity="end"
+                android:contentDescription="@string/action_rename"
+                app:iconGravity="textStart"
+                app:icon="@drawable/ic_edit" />
 
             <com.google.android.material.button.MaterialButton
                 style="@style/Widget.Material3.Button.IconButton"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -91,6 +91,13 @@
     <string name="dictionaries_please_wait">Please wait</string>
     <string name="dictionaries_scanning_device">Scanning device for dictionaries…</string>
     <string name="dictionaries_confirm_forget">Forget "%1$s"?</string>
+    <string name="dictionaries_rename_title">Rename dictionary</string>
+    <string name="dictionaries_rename_hint">Display name</string>
+    <string name="dictionaries_original_label">Original: %1$s</string>
+    <string name="action_rename">Rename</string>
+    <string name="action_save">Save</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="action_reset">Reset</string>
     <string name="lookup_nothing_found">Nothing found</string>
     <string name="main_empty_bookmarks">No bookmarks</string>
     <string name="main_empty_history">No history</string>

--- a/src/itkach/aard2/BlobDescriptorListAdapter.java
+++ b/src/itkach/aard2/BlobDescriptorListAdapter.java
@@ -116,7 +116,7 @@ public class BlobDescriptorListAdapter extends RecyclerView.Adapter<BlobDescript
         CharSequence timestamp = DateUtils.getRelativeTimeSpanString(item.createdAt);
         Context context = holder.itemView.getContext();
         holder.titleView.setText(item.key);
-        holder.sourceView.setText(dict == null ? "???" : dict.getLabel());
+        holder.sourceView.setText(SlobHelper.getInstance().getDisplayLabel(dict));
         holder.dateView.setText(timestamp);
         holder.cardView.setChecked(checkStates.get(position, false));
         holder.cardView.setOnLongClickListener(v -> {

--- a/src/itkach/aard2/SlobDescriptorList.java
+++ b/src/itkach/aard2/SlobDescriptorList.java
@@ -26,6 +26,31 @@ public class SlobDescriptorList extends BaseDescriptorList<SlobDescriptor> {
         return false;
     }
 
+    /**
+     * Looks a descriptor up by dictionary id.  Indexed rather than iterated: this runs
+     * on the main thread while binding list items, and a background folder scan can add
+     * or remove entries at the same time, which would break an iterator.
+     */
+    @Nullable
+    public SlobDescriptor getById(@Nullable String id) {
+        if (id == null) {
+            return null;
+        }
+        for (int index = 0; index < size(); index++) {
+            SlobDescriptor descriptor;
+            try {
+                descriptor = get(index);
+            } catch (IndexOutOfBoundsException e) {
+                // The list shrank while we were walking it
+                return null;
+            }
+            if (descriptor != null && id.equals(descriptor.id)) {
+                return descriptor;
+            }
+        }
+        return null;
+    }
+
     @Nullable
     public Dictionary resolve(@NonNull SlobDescriptor sd) {
         return SlobHelper.getInstance().getDictionary(sd.id);

--- a/src/itkach/aard2/SlobHelper.java
+++ b/src/itkach/aard2/SlobHelper.java
@@ -438,6 +438,19 @@ public final class SlobHelper {
         }
     }
 
+    /**
+     * Returns the name to display for a dictionary: the user-defined name from
+     * its descriptor when set, the dictionary's own label otherwise.
+     */
+    @NonNull
+    public String getDisplayLabel(@Nullable Dictionary dict) {
+        if (dict == null) {
+            return "???";
+        }
+        SlobDescriptor descriptor = dictionaries.getById(dict.getId());
+        return descriptor != null ? descriptor.getLabel() : dict.getLabel();
+    }
+
     @Nullable
     public Dictionary findDictionary(@NonNull String dictIdOrUri) {
         checkInitialized();

--- a/src/itkach/aard2/article/ArticleCollectionActivity.java
+++ b/src/itkach/aard2/article/ArticleCollectionActivity.java
@@ -211,7 +211,7 @@ public class ArticleCollectionActivity extends AppCompatActivity
         CharSequence pageTitle = pagerAdapter.getPageTitle(position);
         ActionBar actionBar = requireActionBar();
         if (entry != null) {
-            String dictLabel = entry.owner.getLabel();
+            String dictLabel = SlobHelper.getInstance().getDisplayLabel(entry.owner);
             actionBar.setTitle(dictLabel);
             if (!AppPrefs.disableHistory() && !isHistory) {
                 SlobHelper slobHelper = SlobHelper.getInstance();

--- a/src/itkach/aard2/descriptor/DescriptorStore.java
+++ b/src/itkach/aard2/descriptor/DescriptorStore.java
@@ -98,6 +98,7 @@ public class DescriptorStore<T extends BaseDescriptor> {
                         d.tags.put(entry.getKey(), entry.getValue().asText(""));
                     }
                 }
+                d.displayName = getText(root, "displayName");
                 d.active = getBoolean(root, "active", true);
                 d.priority = getLong(root, "priority", 0L);
                 d.blobCount = getLong(root, "blobCount", 0L);
@@ -181,6 +182,7 @@ public class DescriptorStore<T extends BaseDescriptor> {
                 root.put("path", d.path);
                 root.put("mddPath", d.mddPath);
                 root.set("tags", mapper.valueToTree(d.tags));
+                root.put("displayName", d.displayName);
                 root.put("active", d.active);
                 root.put("priority", d.priority);
                 root.put("blobCount", d.blobCount);

--- a/src/itkach/aard2/descriptor/SlobDescriptor.java
+++ b/src/itkach/aard2/descriptor/SlobDescriptor.java
@@ -5,7 +5,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
-import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -54,6 +53,15 @@ public class SlobDescriptor extends BaseDescriptor {
 
     @JsonProperty("tags")
     public Map<String, String> tags = new HashMap<>();
+
+    /**
+     * User-defined name shown instead of the dictionary's own label.  Kept in
+     * its own field because {@link #tags} is overwritten on every load.
+     * {@code null} when the user has not renamed the dictionary.
+     */
+    @JsonProperty("displayName")
+    @Nullable
+    public String displayName;
 
     @JsonProperty("active")
     public boolean active = true;
@@ -211,10 +219,27 @@ public class SlobDescriptor extends BaseDescriptor {
     // Display helpers
     // -----------------------------------------------------------------------
 
+    /**
+     * Returns the name to display for this dictionary: the user-defined
+     * {@link #displayName} when set, the dictionary's own label otherwise.
+     */
     @NonNull
     public String getLabel() {
+        if (displayName != null && !displayName.trim().isEmpty()) {
+            return displayName;
+        }
+        return getOriginalLabel();
+    }
+
+    /**
+     * Returns the label embedded in the dictionary file, ignoring any
+     * user-defined {@link #displayName}.
+     */
+    @NonNull
+    public String getOriginalLabel() {
         String label = tags.get(SlobTags.TAG_LABEL);
-        if (TextUtils.isEmpty(label)) {
+        // Plain null/empty checks (not TextUtils) so this stays unit-testable.
+        if (label == null || label.isEmpty()) {
             return "???";
         }
         return label;

--- a/src/itkach/aard2/dictionaries/DictionaryListAdapter.java
+++ b/src/itkach/aard2/dictionaries/DictionaryListAdapter.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -37,6 +38,7 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
     private final DictionaryListFragment fragment;
     private final View.OnClickListener openUrlOnClick;
     private AlertDialog deleteConfirmationDialog;
+    private AlertDialog renameDialog;
 
     private final static String hrefTemplate = "<a href='%1$s'>%2$s</a>";
 
@@ -105,6 +107,7 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
         holder.sourceView.setOnClickListener(openUrlOnClick);
         holder.forgetBtn.setOnClickListener(v -> forget(context, position));
         holder.updateBtn.setOnClickListener(v -> fragment.updateDictionary(desc));
+        holder.renameBtn.setOnClickListener(v -> rename(context, position));
 
         // Enable/disable dictionary
         holder.activeSwitch.setChecked(desc.active);
@@ -127,16 +130,24 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
         holder.blobCountView.setVisibility(desc.error == null ? View.VISIBLE : View.GONE);
         holder.blobCountView.setText(context.getResources().getQuantityString(R.plurals.dict_item_count,
                 (int) blobCount, blobCount));
-        // 3. Copyright
+        // 3. Original label, only meaningful once the dictionary has been renamed
+        boolean renamed = !TextUtils.isEmpty(desc.displayName);
+        holder.originalLabelContainer.setVisibility(renamed ? View.VISIBLE : View.GONE);
+        holder.originalLabelContainer.setEnabled(available);
+        if (renamed) {
+            holder.originalLabelView.setText(
+                    context.getString(R.string.dictionaries_original_label, desc.getOriginalLabel()));
+        }
+        // 4. Copyright
         String copyright = desc.tags.get(SlobTags.TAG_COPYRIGHT);
         holder.copyrightView.setText(copyright);
         holder.copyrightContainer.setVisibility(TextUtils.isEmpty(copyright) ? View.GONE : View.VISIBLE);
         holder.copyrightContainer.setEnabled(available);
-        // 4. License
+        // 5. License
         setupLicenseView(desc, available, holder);
-        // 5. Source
+        // 6. Source
         setupSourceView(desc, available, holder);
-        // 6. Path
+        // 7. Path
         holder.pathView.setText(fileName);
         holder.pathContainer.setEnabled(available);
 
@@ -201,6 +212,48 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
         licenseRow.setEnabled(available);
     }
 
+    /**
+     * Asks for a user-defined display name for the dictionary at {@code position}.
+     * An empty name (or the Reset button) restores the dictionary's own label.
+     * The dialog is modal, so the list cannot be reordered from the UI while it is
+     * open, but it can still change under a background folder scan.
+     */
+    private void rename(Context context, int position) {
+        SlobDescriptor desc = data.get(position);
+        if (desc == null) {
+            return;
+        }
+        View content = LayoutInflater.from(context).inflate(R.layout.dialog_rename_dictionary, null);
+        EditText input = content.findViewById(R.id.dictionary_rename_input);
+        input.setText(desc.displayName == null ? "" : desc.displayName);
+        input.setSelection(input.getText().length());
+        renameDialog = new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.dictionaries_rename_title)
+                .setView(content)
+                .setPositiveButton(R.string.action_save, (dialog, which) -> {
+                    String name = input.getText().toString().trim();
+                    setDisplayName(desc, name.isEmpty() ? null : name);
+                })
+                .setNeutralButton(R.string.action_reset, (dialog, which) -> setDisplayName(desc, null))
+                .setNegativeButton(R.string.action_cancel, null)
+                .create();
+        renameDialog.setOnDismissListener(dialogInterface -> renameDialog = null);
+        renameDialog.show();
+    }
+
+    private void setDisplayName(@NonNull SlobDescriptor desc, @Nullable String displayName) {
+        // A background folder scan can add or remove dictionaries while the dialog is
+        // open, so resolve the position again instead of trusting the bound one.
+        int position = data.indexOf(desc);
+        if (position < 0) {
+            Log.d(TAG, "Dictionary is gone, not renaming: " + desc.path);
+            return;
+        }
+        desc.displayName = displayName;
+        // Persists the descriptor and notifies observers
+        data.set(position, desc);
+    }
+
     private void forget(Context context, int position) {
         SlobDescriptor desc = data.get(position);
         final String label = desc.getLabel();
@@ -254,6 +307,7 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
         public final MaterialButton toggleFavoriteBtn;
         public final MaterialButton updateBtn;
         public final MaterialButton forgetBtn;
+        public final MaterialButton renameBtn;
         public final MaterialTextView titleView;
         public final View errorContainer;
         public final MaterialTextView errorView;
@@ -264,6 +318,8 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
         public final MaterialTextView sourceView;
         public final View copyrightContainer;
         public final MaterialTextView copyrightView;
+        public final View originalLabelContainer;
+        public final MaterialTextView originalLabelView;
         public final View pathContainer;
         public final MaterialTextView pathView;
 
@@ -277,6 +333,7 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
             toggleFavoriteBtn = itemView.findViewById(R.id.dictionary_btn_toggle_fav);
             updateBtn = itemView.findViewById(R.id.dictionary_btn_update);
             forgetBtn = itemView.findViewById(R.id.dictionary_btn_forget);
+            renameBtn = itemView.findViewById(R.id.dictionary_btn_rename);
             titleView = itemView.findViewById(R.id.dictionary_label);
             errorContainer = itemView.findViewById(R.id.dictionary_error_row);
             errorView = itemView.findViewById(R.id.dictionary_error);
@@ -287,6 +344,8 @@ public class DictionaryListAdapter extends RecyclerView.Adapter<DictionaryListAd
             sourceView = itemView.findViewById(R.id.dictionary_source);
             copyrightContainer = itemView.findViewById(R.id.dictionary_copyright_row);
             copyrightView = itemView.findViewById(R.id.dictionary_copyright);
+            originalLabelContainer = itemView.findViewById(R.id.dictionary_original_label_row);
+            originalLabelView = itemView.findViewById(R.id.dictionary_original_label);
             pathContainer = itemView.findViewById(R.id.dictionary_path_row);
             pathView = itemView.findViewById(R.id.dictionary_path);
         }

--- a/src/itkach/aard2/dictionaries/DictionaryListViewModel.java
+++ b/src/itkach/aard2/dictionaries/DictionaryListViewModel.java
@@ -111,6 +111,9 @@ public class DictionaryListViewModel extends AndroidViewModel {
                 SlobHelper slobHelper = SlobHelper.getInstance();
                 SlobDescriptorList dictionaries = slobHelper.dictionaries;
                 SlobDescriptor newSd = SlobDescriptor.fromUri(getApplication(), newUri);
+                // The replacement is a new edition of the same dictionary: keep the name
+                // the user gave it, otherwise updating a file silently discards it.
+                newSd.displayName = dictionaryToBeReplaced.displayName;
                 if (!dictionaries.hasId(dictionaryToBeReplaced.id)) {
                     // Dictionary to be replaced does not exist for some reason
                     if (!dictionaries.hasId(newSd.id)) {

--- a/src/itkach/aard2/lookup/LookupResultAdapter.java
+++ b/src/itkach/aard2/lookup/LookupResultAdapter.java
@@ -18,6 +18,7 @@ import com.google.android.material.elevation.SurfaceColors;
 import java.util.List;
 
 import itkach.aard2.R;
+import itkach.aard2.SlobHelper;
 import itkach.aard2.article.ArticleCollectionActivity;
 import itkach.aard2.dictionary.Dictionary;
 import itkach.aard2.dictionary.DictionaryEntry;
@@ -79,7 +80,7 @@ public class LookupResultAdapter extends RecyclerView.Adapter<LookupResultAdapte
 
         holder.itemView.setVisibility(View.VISIBLE);
         holder.titleView.setText(item.key);
-        holder.sourceView.setText(dict == null ? "???" : dict.getLabel());
+        holder.sourceView.setText(SlobHelper.getInstance().getDisplayLabel(dict));
         holder.cardView.setOnClickListener(v -> {
             Intent intent = new Intent(context, ArticleCollectionActivity.class);
             intent.putExtra("position", position);

--- a/src/test/java/itkach/aard2/descriptor/DescriptorStoreTest.java
+++ b/src/test/java/itkach/aard2/descriptor/DescriptorStoreTest.java
@@ -1,0 +1,100 @@
+package itkach.aard2.descriptor;
+
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import itkach.aard2.slob.SlobTags;
+
+/**
+ * Unit tests for {@link DescriptorStore} persistence of {@link SlobDescriptor}.
+ *
+ * <p>{@code save()} serialises the descriptor field by field, so a field added to the
+ * model is silently dropped unless it is written there too — these tests guard the
+ * round trip.</p>
+ */
+public class DescriptorStoreTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private DescriptorStore<SlobDescriptor> store;
+
+    @Before
+    public void setUp() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        store = new DescriptorStore<>(mapper, folder.newFolder("dictionaries"));
+    }
+
+    private static SlobDescriptor descriptor() {
+        SlobDescriptor descriptor = new SlobDescriptor();
+        descriptor.id = "9c90918b-b27c-5e04-a8d6-118623023162";
+        descriptor.format = SlobDescriptor.FORMAT_STARDICT;
+        descriptor.path = "content://dictionaries/wikipedia-en.ifo";
+        descriptor.tags.put(SlobTags.TAG_LABEL, "Wikipedia (en)");
+        descriptor.blobCount = 4;
+        return descriptor;
+    }
+
+    private SlobDescriptor saveAndReload(SlobDescriptor descriptor) {
+        store.save(descriptor);
+        List<SlobDescriptor> loaded = store.load(SlobDescriptor.class);
+        assertEquals(1, loaded.size());
+        return loaded.get(0);
+    }
+
+    @Test
+    public void displayNameSurvivesRoundTrip() {
+        SlobDescriptor descriptor = descriptor();
+        descriptor.displayName = "Simple Wikipedia";
+        SlobDescriptor reloaded = saveAndReload(descriptor);
+        assertEquals("Simple Wikipedia", reloaded.displayName);
+        assertEquals("Simple Wikipedia", reloaded.getLabel());
+        assertEquals("Wikipedia (en)", reloaded.getOriginalLabel());
+    }
+
+    @Test
+    public void missingDisplayNameStaysNull() {
+        SlobDescriptor reloaded = saveAndReload(descriptor());
+        assertNull(reloaded.displayName);
+        assertEquals("Wikipedia (en)", reloaded.getLabel());
+    }
+
+    @Test
+    public void legacyRecoveryKeepsDisplayName() throws IOException {
+        SlobDescriptor descriptor = descriptor();
+        // blobCount as a string makes the annotation-driven read fail, so load() falls
+        // back to the field-by-field legacy recovery
+        String json = "{\"id\":\"" + descriptor.id + "\","
+                + "\"format\":\"stardict\","
+                + "\"path\":\"" + descriptor.path + "\","
+                + "\"tags\":{\"label\":\"Wikipedia (en)\"},"
+                + "\"displayName\":\"Simple Wikipedia\","
+                + "\"blobCount\":\"not a number\"}";
+        File saved = new File(folder.getRoot(), "dictionaries/" + descriptor.id);
+        try (Writer writer = new OutputStreamWriter(
+                new FileOutputStream(saved), StandardCharsets.UTF_8)) {
+            writer.write(json);
+        }
+
+        List<SlobDescriptor> loaded = store.load(SlobDescriptor.class);
+        assertEquals(1, loaded.size());
+        assertEquals("Simple Wikipedia", loaded.get(0).displayName);
+        assertEquals("Simple Wikipedia", loaded.get(0).getLabel());
+    }
+}

--- a/src/test/java/itkach/aard2/descriptor/SlobDescriptorTest.java
+++ b/src/test/java/itkach/aard2/descriptor/SlobDescriptorTest.java
@@ -1,0 +1,57 @@
+package itkach.aard2.descriptor;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import itkach.aard2.slob.SlobTags;
+
+/**
+ * Unit tests for {@link SlobDescriptor} display-name resolution.
+ *
+ * <p>Only the label helpers are covered: they are the sole part of the
+ * descriptor with no Android dependency.</p>
+ */
+public class SlobDescriptorTest {
+
+    private SlobDescriptor descriptor;
+
+    @Before
+    public void setUp() {
+        descriptor = new SlobDescriptor();
+        descriptor.tags.put(SlobTags.TAG_LABEL, "Wikipedia (en)");
+    }
+
+    @Test
+    public void labelFallsBackToDictionaryLabel() {
+        assertEquals("Wikipedia (en)", descriptor.getLabel());
+    }
+
+    @Test
+    public void customNameOverridesDictionaryLabel() {
+        descriptor.displayName = "Simple Wikipedia";
+        assertEquals("Simple Wikipedia", descriptor.getLabel());
+    }
+
+    @Test
+    public void blankCustomNameFallsBackToDictionaryLabel() {
+        descriptor.displayName = "   ";
+        assertEquals("Wikipedia (en)", descriptor.getLabel());
+        descriptor.displayName = "";
+        assertEquals("Wikipedia (en)", descriptor.getLabel());
+    }
+
+    @Test
+    public void missingLabelTagYieldsPlaceholder() {
+        descriptor.tags.clear();
+        assertEquals("???", descriptor.getLabel());
+        assertEquals("???", descriptor.getOriginalLabel());
+    }
+
+    @Test
+    public void originalLabelIgnoresCustomName() {
+        descriptor.displayName = "Simple Wikipedia";
+        assertEquals("Wikipedia (en)", descriptor.getOriginalLabel());
+    }
+}


### PR DESCRIPTION
## Summary

- Add a per-dictionary display name, set from a new rename button on each dictionary card (Save / Reset / Cancel). Empty name or Reset restores the dictionary's own label.
- The custom name replaces the embedded label everywhere it is shown: dictionary list, lookup results, bookmarks and history, article title bar. This is the point of the issue — two files labelled "Wikipedia (en)" are now distinguishable in results.
- Once renamed, the card details show the original label so the file's own identity stays visible.
- The name is persisted with the descriptor and carried over when a dictionary file is replaced via the update button.

Ordering was already covered by the existing favorites/priority sort, as noted in the issue thread, so this PR only adds naming.

## Testing

- `./gradlew assembleDebug` compiles; `./gradlew lint` shows no new issue beyond `MissingTranslation` for the 7 new English strings (Weblate supplies translations).
- New JUnit tests: `SlobDescriptorTest` (label resolution) and `DescriptorStoreTest` (persistence round trip, including the legacy recovery path). Both mutation-checked. The rest of the suite stays at its known-red baseline.
- Verified on an emulator: rename → list title, lookup result source, article title bar and bookmarks all show the custom name; the name survives a force-stop; Reset reverts everything; replacing a dictionary file keeps the name.

Reviewer scenarios worth repeating by hand: renaming with two same-labelled dictionaries loaded, and rotating the device with the rename dialog open.

## Notes

- Two pre-existing issues surfaced while testing, neither introduced here and neither fixed here:
  - `DescriptorStore.save()` serialises `SlobDescriptor` field by field, so any field added to the model is silently dropped unless it is added there too. Fixed for the new field, and `DescriptorStoreTest` now guards it, but the pattern remains a trap.
  - For a dictionary inside an auto-load folder, the update button registers a document URI while the folder scan uses tree URIs. The next scan therefore drops the replaced descriptor and re-adds it fresh, losing its custom name — and equally its favorite/active state, which is the pre-existing part.
- The rename dialog is not dismissed on fragment destroy, so it can leak a window on rotation. This matches the existing "forget" confirmation dialog in the same adapter; fixing it properly means a lifecycle hook for both, which felt out of scope here.

Closes #97